### PR TITLE
fix(docker): add restart unless-stopped policy to all services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ artifacts/
 .cline_rules
 .engram/
 openspec/
+AGENTS.md
 
 # ─── Archives / temp ──────────────────────────────────────────────────────────
 *.rar

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   db:
+    restart: unless-stopped
     image: mariadb:10.11
     container_name: radius-db
     env_file:
@@ -23,6 +24,7 @@ services:
       retries: 3
 
   radius:
+    restart: unless-stopped
     build:
       context: ./radius
     container_name: radius-server
@@ -49,6 +51,7 @@ services:
         condition: service_healthy
 
   backend:
+    restart: unless-stopped
     build:
       context: ./backend
     container_name: radius-backend
@@ -72,6 +75,7 @@ services:
       - radius-net
 
   frontend:
+    restart: unless-stopped
     build:
       context: ./frontend
     container_name: radius-frontend


### PR DESCRIPTION
Closes #9

## Type
- [x] Bug fix

## Summary
- Add `restart: unless-stopped` to all 4 services in `docker-compose.yml` (db, backend, frontend, freeradius)
- Update `.gitignore` to exclude AI agent artifacts

## Changes

| File | Change |
|------|--------|
| `docker-compose.yml` | Added `restart: unless-stopped` to db, backend, frontend, and freeradius services |
| `.gitignore` | Updated to exclude agent config folders |

## Test Plan
- [x] Manually verified services restart after docker-compose down and docker-compose up -d
- [x] Confirmed policy applies to all 4 services