### PR TITLE
feat(dictionary): expose built-in RADIUS attrs in group attribute sel…

### DIFF
--- a/backend/app/routers/dictionary.py
+++ b/backend/app/routers/dictionary.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.db.session import get_db
 from app.models.models import AdminUser
-from app.services.dictionary_loader import dictionary_service
+from app.services.dictionary_loader import dictionary_service, _parse_builtin_attr_grep_output
 from app.services.audit import log_audit
 from app.core.security import get_current_active_user
 import logging
@@ -12,7 +12,43 @@ import docker as docker_sdk
 
 logger = logging.getLogger(__name__)
 
+# Module-level cache for built-in RADIUS attributes.
+# Populated lazily on first request; survives for the process lifetime because
+# built-in dictionaries never change while the container is running.
+_builtin_attr_cache: Optional[List] = None
+
 router = APIRouter(prefix="/dictionary", tags=["dictionary"])
+
+
+def _get_builtin_attributes_cached() -> List:
+    """Return RADIUS attributes from FreeRADIUS built-in vendor dictionaries.
+
+    Uses Docker exec to grep the radius-server container once; subsequent calls
+    return the in-memory result without touching Docker again.
+
+    Gracefully returns an empty list when the container is unavailable (e.g.
+    in unit-test environments or during local development without Docker).
+    """
+    global _builtin_attr_cache
+    if _builtin_attr_cache is not None:
+        return _builtin_attr_cache
+
+    try:
+        grep_output = _exec_in_radius([
+            "grep", "-rE",
+            "^(ATTRIBUTE|VENDOR|BEGIN-VENDOR|END-VENDOR)",
+            "/usr/share/freeradius/",
+        ])
+        _builtin_attr_cache = _parse_builtin_attr_grep_output(grep_output)
+        logger.info(
+            "Loaded %d built-in RADIUS attributes from radius-server container",
+            len(_builtin_attr_cache),
+        )
+    except Exception as exc:
+        logger.warning("Could not load built-in RADIUS attributes: %s", exc)
+        _builtin_attr_cache = []
+
+    return _builtin_attr_cache
 
 
 def _reload_radius() -> None:
@@ -288,8 +324,23 @@ async def get_builtin_dictionary_content(
 async def get_attributes(
     current_user: AdminUser = Depends(get_current_active_user),
 ):
-    """Get all available RADIUS attributes from loaded dictionaries."""
-    return dictionary_service.get_attributes()
+    """Get all available RADIUS attributes from custom and built-in dictionaries.
+
+    Merges attributes from:
+    1. Custom dictionaries uploaded by the user (``backend/dictionaries/``)
+    2. FreeRADIUS built-in vendor dictionaries (``/usr/share/freeradius/``)
+
+    Custom attributes always take precedence over built-ins with the same name.
+    Built-in attributes are tagged with a ``[Sistema] dictionary.*`` prefix in
+    the ``dictionary`` field so the UI can group them separately.
+    """
+    custom_attrs = dictionary_service.get_attributes()
+    builtin_attrs = _get_builtin_attributes_cached()
+
+    # Custom attrs win on name collision — avoids duplicates in the selector
+    custom_names = {a["name"] for a in custom_attrs}
+    merged = custom_attrs + [a for a in builtin_attrs if a["name"] not in custom_names]
+    return sorted(merged, key=lambda x: x["name"])
 
 
 @router.get("/values/{attribute_name}", response_model=List[AttributeValue])

--- a/backend/app/services/dictionary_loader.py
+++ b/backend/app/services/dictionary_loader.py
@@ -77,6 +77,102 @@ _VENDOR_RE = re.compile(
     re.IGNORECASE | re.MULTILINE,
 )
 
+# ---------- Built-in dictionary attribute parser ----------
+
+# Matches:  ATTRIBUTE <name> <code> <type>  [optional-extras...]
+_BUILTIN_ATTR_LINE_RE = re.compile(
+    r"^ATTRIBUTE\s+(\S+)\s+(\d+)\s+(\S+)",
+    re.IGNORECASE,
+)
+_BUILTIN_BEGIN_VENDOR_RE = re.compile(r"^BEGIN-VENDOR\s+(\S+)", re.IGNORECASE)
+_BUILTIN_END_VENDOR_RE = re.compile(r"^END-VENDOR", re.IGNORECASE)
+
+
+def _parse_builtin_attr_grep_output(grep_output: str) -> List[Dict]:
+    """Parse ``grep -rE`` output into RADIUS attribute dicts compatible with
+    ``DictionaryService.get_attributes()``.
+
+    Expected input is the combined stdout of::
+
+        grep -rE "^(ATTRIBUTE|VENDOR|BEGIN-VENDOR|END-VENDOR)" \\
+             /usr/share/freeradius/
+
+    Each input line has the form::
+
+        /usr/share/freeradius/dictionary.cisco:ATTRIBUTE  Cisco-AVPair  1  string
+
+    The function tracks BEGIN-VENDOR / END-VENDOR state **per source file**
+    because ``grep -r`` interleaves lines from multiple files.
+
+    Returns a list of dicts with keys:
+        name, code (int), type (str), vendor (str), dictionary (str)
+
+    The ``dictionary`` value is prefixed with ``[Sistema]`` so the
+    AttributeSelector component groups built-ins separately from custom files.
+
+    Duplicate attribute names across built-in files are deduplicated; the
+    first occurrence wins (files are processed in filesystem order).
+    """
+    # vendor_ctx maps filename → current vendor name (None if outside a BEGIN-VENDOR block)
+    vendor_ctx: Dict[str, Optional[str]] = {}
+    attrs: List[Dict] = []
+    seen_names: Set[str] = set()
+
+    for raw_line in grep_output.splitlines():
+        raw_line = raw_line.strip()
+        if not raw_line:
+            continue
+
+        # grep -r format: /path/to/file:content
+        colon_idx = raw_line.find(":")
+        if colon_idx == -1:
+            continue
+
+        filepath = raw_line[:colon_idx]
+        content = raw_line[colon_idx + 1:].strip()
+
+        if not content or content.startswith("#"):
+            continue
+
+        filename = os.path.basename(filepath)
+
+        # Track BEGIN-VENDOR / END-VENDOR state per file
+        bm = _BUILTIN_BEGIN_VENDOR_RE.match(content)
+        if bm:
+            vendor_ctx[filename] = bm.group(1)
+            continue
+
+        if _BUILTIN_END_VENDOR_RE.match(content):
+            vendor_ctx[filename] = None
+            continue
+
+        # VENDOR declaration lines carry no attribute data — skip
+        if re.match(r"^VENDOR\s", content, re.IGNORECASE):
+            continue
+
+        am = _BUILTIN_ATTR_LINE_RE.match(content)
+        if not am:
+            continue
+
+        name, code, attr_type = am.group(1), am.group(2), am.group(3)
+
+        # Dedup: first occurrence wins (alphabetical file order via grep -r)
+        if name in seen_names:
+            continue
+        seen_names.add(name)
+
+        vendor = vendor_ctx.get(filename) or "IETF (Standard)"
+        attrs.append({
+            "name": name,
+            "code": int(code),
+            "type": attr_type,
+            "vendor": vendor,
+            "dictionary": f"[Sistema] {filename}",
+        })
+
+    return attrs
+
+
 
 def _load_base_attribute_names() -> Set[str]:
     """Load all attribute names from pyrad's built-in dictionary.

--- a/backend/tests/integration/test_dictionary.py
+++ b/backend/tests/integration/test_dictionary.py
@@ -4,10 +4,15 @@ Integration tests: /dictionary endpoint.
 Verifies:
 - Any authenticated role can list dictionary files (GET /dictionary/files)
 - Any authenticated role can query attributes (GET /dictionary/attributes)
+- GET /dictionary/attributes gracefully handles Docker unavailability
+- GET /dictionary/builtin returns a list of built-in vendor dictionaries
+- GET /dictionary/builtin/{filename} returns file content
+- Path traversal is rejected on /dictionary/builtin/{filename}
 - Unauthenticated requests are rejected
 """
 
 import pytest
+from unittest.mock import patch
 
 
 class TestDictionaryRead:
@@ -57,3 +62,170 @@ class TestDictionaryRead:
     async def test_unauthenticated_cannot_list_attributes(self, async_client):
         resp = await async_client.get("/dictionary/attributes")
         assert resp.status_code in (401, 403)
+
+
+class TestAttributesMerge:
+    """GET /dictionary/attributes — merges custom + built-in dicts."""
+
+    async def test_attributes_returns_200_when_docker_unavailable(
+        self, async_client, superadmin_token
+    ):
+        """When Docker / radius-server is not reachable, endpoint must still
+        return 200 with the custom dict attributes (graceful degradation)."""
+        import app.routers.dictionary as dict_router
+        dict_router._builtin_attr_cache = None
+
+        with patch(
+            "app.routers.dictionary._exec_in_radius",
+            side_effect=RuntimeError("Docker not available"),
+        ):
+            resp = await async_client.get(
+                "/dictionary/attributes",
+                headers={"Authorization": f"Bearer {superadmin_token}"},
+            )
+        assert resp.status_code == 200
+        assert isinstance(resp.json(), list)
+
+    async def test_attributes_includes_builtin_when_docker_available(
+        self, async_client, superadmin_token
+    ):
+        """When Docker returns valid grep output, built-in attrs appear in the list."""
+        mock_grep = (
+            "/usr/share/freeradius/dictionary.cisco:BEGIN-VENDOR\tCisco\n"
+            "/usr/share/freeradius/dictionary.cisco:ATTRIBUTE\tCisco-AVPair\t1\tstring\n"
+            "/usr/share/freeradius/dictionary.cisco:END-VENDOR\tCisco\n"
+        )
+        import app.routers.dictionary as dict_router
+        dict_router._builtin_attr_cache = None
+
+        with patch(
+            "app.routers.dictionary._exec_in_radius",
+            return_value=mock_grep,
+        ):
+            resp = await async_client.get(
+                "/dictionary/attributes",
+                headers={"Authorization": f"Bearer {superadmin_token}"},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        names = [a["name"] for a in data]
+        assert "Cisco-AVPair" in names
+
+    async def test_builtin_attrs_tagged_with_sistema_prefix(
+        self, async_client, superadmin_token
+    ):
+        """Built-in attribute dictionary field must start with '[Sistema]'."""
+        mock_grep = (
+            "/usr/share/freeradius/dictionary.cisco:BEGIN-VENDOR\tCisco\n"
+            "/usr/share/freeradius/dictionary.cisco:ATTRIBUTE\tCisco-AVPair\t1\tstring\n"
+            "/usr/share/freeradius/dictionary.cisco:END-VENDOR\tCisco\n"
+        )
+        import app.routers.dictionary as dict_router
+        dict_router._builtin_attr_cache = None
+
+        with patch(
+            "app.routers.dictionary._exec_in_radius",
+            return_value=mock_grep,
+        ):
+            resp = await async_client.get(
+                "/dictionary/attributes",
+                headers={"Authorization": f"Bearer {superadmin_token}"},
+            )
+
+        data = resp.json()
+        cisco_attr = next((a for a in data if a["name"] == "Cisco-AVPair"), None)
+        assert cisco_attr is not None
+        assert cisco_attr["dictionary"].startswith("[Sistema]")
+        assert cisco_attr["vendor"] == "Cisco"
+
+
+class TestBuiltinDictionaryEndpoint:
+    """GET /dictionary/builtin and GET /dictionary/builtin/{filename}."""
+
+    async def test_list_builtin_requires_auth(self, async_client):
+        resp = await async_client.get("/dictionary/builtin")
+        assert resp.status_code in (401, 403)
+
+    async def test_list_builtin_returns_list_when_docker_available(
+        self, async_client, superadmin_token
+    ):
+        mock_ls = "dictionary.cisco\ndictionary.microsoft\n"
+        with patch(
+            "app.routers.dictionary._exec_in_radius",
+            return_value=mock_ls,
+        ):
+            resp = await async_client.get(
+                "/dictionary/builtin",
+                headers={"Authorization": f"Bearer {superadmin_token}"},
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, list)
+        assert len(data) == 2
+        vendors = [d["vendor"] for d in data]
+        assert "cisco" in vendors
+        assert "microsoft" in vendors
+
+    async def test_list_builtin_returns_503_when_docker_unavailable(
+        self, async_client, superadmin_token
+    ):
+        with patch(
+            "app.routers.dictionary._exec_in_radius",
+            side_effect=RuntimeError("Docker not available"),
+        ):
+            resp = await async_client.get(
+                "/dictionary/builtin",
+                headers={"Authorization": f"Bearer {superadmin_token}"},
+            )
+        assert resp.status_code == 503
+
+    async def test_get_builtin_content_requires_auth(self, async_client):
+        resp = await async_client.get("/dictionary/builtin/dictionary.cisco")
+        assert resp.status_code in (401, 403)
+
+    async def test_get_builtin_content_returns_text(
+        self, async_client, superadmin_token
+    ):
+        mock_content = "VENDOR\tCisco\t9\nATTRIBUTE\tCisco-AVPair\t1\tstring\n"
+        with patch(
+            "app.routers.dictionary._exec_in_radius",
+            return_value=mock_content,
+        ):
+            resp = await async_client.get(
+                "/dictionary/builtin/dictionary.cisco",
+                headers={"Authorization": f"Bearer {superadmin_token}"},
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["filename"] == "dictionary.cisco"
+        assert "Cisco-AVPair" in data["content"]
+        assert data["builtin"] is True
+
+    async def test_regression_path_traversal_blocked(
+        self, async_client, superadmin_token
+    ):
+        """GET /dictionary/builtin/../../../etc/passwd must return 400.
+
+        Regression for potential path traversal via filename parameter.
+        """
+        resp = await async_client.get(
+            "/dictionary/builtin/../../../etc/passwd",
+            headers={"Authorization": f"Bearer {superadmin_token}"},
+        )
+        # FastAPI URL decoding may change the path, but our regex validation
+        # should catch any non-matching filename pattern.
+        assert resp.status_code in (400, 404, 422)
+
+    async def test_regression_filename_without_dictionary_prefix_blocked(
+        self, async_client, superadmin_token
+    ):
+        """Only filenames matching 'dictionary.*' pattern are allowed.
+
+        Regression: arbitrary filenames like 'shadow' must be rejected.
+        """
+        resp = await async_client.get(
+            "/dictionary/builtin/shadow",
+            headers={"Authorization": f"Bearer {superadmin_token}"},
+        )
+        assert resp.status_code == 400

--- a/backend/tests/unit/test_dictionary_loader.py
+++ b/backend/tests/unit/test_dictionary_loader.py
@@ -1,0 +1,204 @@
+"""
+Unit tests for dictionary_loader._parse_builtin_attr_grep_output.
+
+No Docker, no filesystem, no DB required — purely tests the regex parser
+that converts ``grep -rE`` output from the radius-server container into
+attribute dicts compatible with DictionaryService.get_attributes().
+
+Coverage targets (dictionary_loader.py was at 34%):
+- Basic ATTRIBUTE parsing
+- BEGIN-VENDOR / END-VENDOR tracking per file
+- IETF (Standard) fallback when attribute is outside any vendor block
+- Deduplication across files (first occurrence wins)
+- Graceful handling of blank lines, comments, and unknown keywords
+- [Sistema] prefix in the dictionary field
+"""
+
+import pytest
+from app.services.dictionary_loader import _parse_builtin_attr_grep_output
+
+
+# ---------------------------------------------------------------------------
+# Minimal grep output snippets used across tests
+# ---------------------------------------------------------------------------
+
+_CISCO_GREP_OUTPUT = """\
+/usr/share/freeradius/dictionary.cisco:VENDOR\t\tCisco\t\t9
+/usr/share/freeradius/dictionary.cisco:BEGIN-VENDOR\tCisco
+/usr/share/freeradius/dictionary.cisco:ATTRIBUTE\tCisco-AVPair\t\t1\tstring
+/usr/share/freeradius/dictionary.cisco:ATTRIBUTE\tCisco-NAS-Port\t\t2\tinteger
+/usr/share/freeradius/dictionary.cisco:END-VENDOR\tCisco
+"""
+
+_MICROSOFT_GREP_OUTPUT = """\
+/usr/share/freeradius/dictionary.microsoft:VENDOR\t\tMicrosoft\t\t311
+/usr/share/freeradius/dictionary.microsoft:BEGIN-VENDOR\tMicrosoft
+/usr/share/freeradius/dictionary.microsoft:ATTRIBUTE\tMS-CHAP-Response\t\t1\toctets
+/usr/share/freeradius/dictionary.microsoft:ATTRIBUTE\tMS-CHAP-Challenge\t\t11\toctets
+/usr/share/freeradius/dictionary.microsoft:END-VENDOR\tMicrosoft
+"""
+
+# Standard (IETF) attribute — outside any BEGIN-VENDOR block
+_IETF_GREP_OUTPUT = """\
+/usr/share/freeradius/dictionary:ATTRIBUTE\tUser-Name\t\t1\tstring
+/usr/share/freeradius/dictionary:ATTRIBUTE\tUser-Password\t\t2\tstring
+/usr/share/freeradius/dictionary:ATTRIBUTE\tService-Type\t\t6\tinteger
+"""
+
+
+class TestParseBuiltinGrepOutput:
+
+    def test_returns_empty_list_on_empty_input(self):
+        result = _parse_builtin_attr_grep_output("")
+        assert result == []
+
+    def test_returns_empty_list_on_blank_lines_only(self):
+        result = _parse_builtin_attr_grep_output("\n\n\n")
+        assert result == []
+
+    def test_returns_empty_list_on_comment_lines_only(self):
+        grep_out = (
+            "/usr/share/freeradius/dictionary.cisco:# This is a comment\n"
+            "/usr/share/freeradius/dictionary.cisco:#ATTRIBUTE  ignored 1 string\n"
+        )
+        result = _parse_builtin_attr_grep_output(grep_out)
+        assert result == []
+
+    # -----------------------------------------------------------------------
+    # Vendor attribute extraction
+    # -----------------------------------------------------------------------
+
+    def test_cisco_attributes_parsed(self):
+        result = _parse_builtin_attr_grep_output(_CISCO_GREP_OUTPUT)
+        names = [a["name"] for a in result]
+        assert "Cisco-AVPair" in names
+        assert "Cisco-NAS-Port" in names
+
+    def test_cisco_attributes_vendor_tagged(self):
+        result = _parse_builtin_attr_grep_output(_CISCO_GREP_OUTPUT)
+        by_name = {a["name"]: a for a in result}
+        assert by_name["Cisco-AVPair"]["vendor"] == "Cisco"
+        assert by_name["Cisco-NAS-Port"]["vendor"] == "Cisco"
+
+    def test_cisco_attribute_code_is_int(self):
+        result = _parse_builtin_attr_grep_output(_CISCO_GREP_OUTPUT)
+        by_name = {a["name"]: a for a in result}
+        assert by_name["Cisco-AVPair"]["code"] == 1
+        assert isinstance(by_name["Cisco-AVPair"]["code"], int)
+
+    def test_cisco_attribute_type_preserved(self):
+        result = _parse_builtin_attr_grep_output(_CISCO_GREP_OUTPUT)
+        by_name = {a["name"]: a for a in result}
+        assert by_name["Cisco-AVPair"]["type"] == "string"
+        assert by_name["Cisco-NAS-Port"]["type"] == "integer"
+
+    def test_dictionary_field_has_sistema_prefix(self):
+        """[Sistema] prefix distinguishes built-ins from custom dicts in the UI."""
+        result = _parse_builtin_attr_grep_output(_CISCO_GREP_OUTPUT)
+        by_name = {a["name"]: a for a in result}
+        assert by_name["Cisco-AVPair"]["dictionary"] == "[Sistema] dictionary.cisco"
+
+    # -----------------------------------------------------------------------
+    # IETF (Standard) attributes — outside any vendor block
+    # -----------------------------------------------------------------------
+
+    def test_ietf_attributes_parsed(self):
+        result = _parse_builtin_attr_grep_output(_IETF_GREP_OUTPUT)
+        names = [a["name"] for a in result]
+        assert "User-Name" in names
+        assert "Service-Type" in names
+
+    def test_ietf_attributes_vendor_is_ietf_standard(self):
+        result = _parse_builtin_attr_grep_output(_IETF_GREP_OUTPUT)
+        by_name = {a["name"]: a for a in result}
+        assert by_name["User-Name"]["vendor"] == "IETF (Standard)"
+
+    def test_ietf_dictionary_field_uses_filename(self):
+        result = _parse_builtin_attr_grep_output(_IETF_GREP_OUTPUT)
+        by_name = {a["name"]: a for a in result}
+        assert by_name["User-Name"]["dictionary"] == "[Sistema] dictionary"
+
+    # -----------------------------------------------------------------------
+    # Multi-file merge and deduplication
+    # -----------------------------------------------------------------------
+
+    def test_merged_cisco_and_microsoft(self):
+        combined = _CISCO_GREP_OUTPUT + _MICROSOFT_GREP_OUTPUT
+        result = _parse_builtin_attr_grep_output(combined)
+        names = [a["name"] for a in result]
+        assert "Cisco-AVPair" in names
+        assert "MS-CHAP-Response" in names
+
+    def test_deduplication_first_occurrence_wins(self):
+        """If the same attribute name appears in two files, first occurrence wins."""
+        dup_output = (
+            "/usr/share/freeradius/dictionary.a:ATTRIBUTE\tDup-Attr\t1\tstring\n"
+            "/usr/share/freeradius/dictionary.b:ATTRIBUTE\tDup-Attr\t2\tinteger\n"
+        )
+        result = _parse_builtin_attr_grep_output(dup_output)
+        dup_attrs = [a for a in result if a["name"] == "Dup-Attr"]
+        assert len(dup_attrs) == 1
+        # First file wins
+        assert dup_attrs[0]["dictionary"] == "[Sistema] dictionary.a"
+        assert dup_attrs[0]["type"] == "string"
+
+    # -----------------------------------------------------------------------
+    # BEGIN-VENDOR / END-VENDOR tracking per file
+    # -----------------------------------------------------------------------
+
+    def test_vendor_context_resets_after_end_vendor(self):
+        """ATTRIBUTE lines after END-VENDOR should be tagged as IETF (Standard)."""
+        grep_out = (
+            "/usr/share/freeradius/dictionary.cisco:BEGIN-VENDOR\tCisco\n"
+            "/usr/share/freeradius/dictionary.cisco:ATTRIBUTE\tCisco-Inside\t1\tstring\n"
+            "/usr/share/freeradius/dictionary.cisco:END-VENDOR\tCisco\n"
+            "/usr/share/freeradius/dictionary.cisco:ATTRIBUTE\tAfter-Vendor\t2\tstring\n"
+        )
+        result = _parse_builtin_attr_grep_output(grep_out)
+        by_name = {a["name"]: a for a in result}
+        assert by_name["Cisco-Inside"]["vendor"] == "Cisco"
+        assert by_name["After-Vendor"]["vendor"] == "IETF (Standard)"
+
+    def test_two_files_independent_vendor_contexts(self):
+        """Vendor context for file A must not bleed into file B."""
+        grep_out = (
+            # file A opens a Cisco block but never closes it
+            "/usr/share/freeradius/dictionary.cisco:BEGIN-VENDOR\tCisco\n"
+            "/usr/share/freeradius/dictionary.cisco:ATTRIBUTE\tCisco-AVPair\t1\tstring\n"
+            # file B has an IETF attribute — should NOT inherit Cisco vendor
+            "/usr/share/freeradius/dictionary.rfc:ATTRIBUTE\tUser-Name\t1\tstring\n"
+        )
+        result = _parse_builtin_attr_grep_output(grep_out)
+        by_name = {a["name"]: a for a in result}
+        assert by_name["Cisco-AVPair"]["vendor"] == "Cisco"
+        assert by_name["User-Name"]["vendor"] == "IETF (Standard)"
+
+    # -----------------------------------------------------------------------
+    # Malformed / edge-case input
+    # -----------------------------------------------------------------------
+
+    def test_lines_without_colon_are_skipped(self):
+        result = _parse_builtin_attr_grep_output("ATTRIBUTE  Something  1  string\n")
+        assert result == []
+
+    def test_attribute_line_without_enough_fields_is_skipped(self):
+        # Missing type field
+        grep_out = "/usr/share/freeradius/dictionary.x:ATTRIBUTE  Broken  1\n"
+        result = _parse_builtin_attr_grep_output(grep_out)
+        assert result == []
+
+    def test_vendor_declaration_line_does_not_produce_attribute(self):
+        """VENDOR lines should not appear in the output."""
+        grep_out = "/usr/share/freeradius/dictionary.cisco:VENDOR\tCisco\t9\n"
+        result = _parse_builtin_attr_grep_output(grep_out)
+        assert result == []
+
+    def test_result_contains_required_keys(self):
+        result = _parse_builtin_attr_grep_output(_CISCO_GREP_OUTPUT)
+        assert len(result) > 0
+        for attr in result:
+            assert "name" in attr
+            assert "code" in attr
+            assert "type" in attr
+            assert "vendor" in attr
+            assert "dictionary" in attr

--- a/frontend/src/test/mocks/handlers.js
+++ b/frontend/src/test/mocks/handlers.js
@@ -126,4 +126,23 @@ export const handlers = [
       },
     ])
   }),
+
+  // -------------------------------------------------------------------------
+  // Dictionary — built-in vendor dicts (read-only view)
+  // -------------------------------------------------------------------------
+  http.get('/api/dictionary/builtin', () => {
+    return HttpResponse.json([
+      { filename: 'dictionary.cisco',     vendor: 'cisco' },
+      { filename: 'dictionary.microsoft', vendor: 'microsoft' },
+      { filename: 'dictionary.mikrotik',  vendor: 'mikrotik' },
+    ])
+  }),
+
+  http.get('/api/dictionary/builtin/:filename', ({ params }) => {
+    return HttpResponse.json({
+      filename: params.filename,
+      content: `# Mock built-in dictionary: ${params.filename}\nATTRIBUTE\tTest-Attr\t1\tstring\n`,
+      builtin: true,
+    })
+  }),
 ]


### PR DESCRIPTION
…ector

- Add _parse_builtin_attr_grep_output() pure function to dictionary_loader.py that parses grep -rE output from /usr/share/freeradius/ into attribute dicts compatible with DictionaryService.get_attributes() output shape. Tracks BEGIN-VENDOR/END-VENDOR state per file; deduplicates across files.

- Add module-level cache _builtin_attr_cache + _get_builtin_attributes_cached() to dictionary.py router. Uses Docker exec to grep the radius-server container once; subsequent calls serve from memory. Gracefully returns [] when Docker is unavailable (unit test environments, local dev without containers).

- Merge custom + built-in attrs in GET /dictionary/attributes endpoint. Custom attrs always win on name collision. Built-in attrs tagged with '[Sistema] dictionary.*' prefix so AttributeSelector groups them separately.

- Add unit tests for _parse_builtin_attr_grep_output (19 tests, pure Python, no Docker required): vendor tracking, deduplication, IETF Standard fallback, multi-file isolation, malformed input handling.

- Add integration tests for /dictionary/attributes merge and /dictionary/builtin endpoints using unittest.mock.patch for Docker isolation.

- Add MSW v2 handlers for /api/dictionary/builtin and /api/dictionary/builtin/:filename in frontend test mocks.