### PR TITLE
feat(groups): add RADIUS groups management UI with full CRUD

### DIFF
--- a/backend/app/routers/groups.py
+++ b/backend/app/routers/groups.py
@@ -377,3 +377,101 @@ async def get_group_members(
         select(RadUserGroup).where(RadUserGroup.groupname == groupname)
     )
     return result.scalars().all()
+
+
+# --- Group Management: Rename and Get by Name ---
+@router.get("/by-name/{groupname}", response_model=None)
+async def get_group_by_name(
+    groupname: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: AdminUser = Depends(get_current_active_user),
+):
+    """Get all reply and check attributes for a specific group."""
+    reply_result = await db.execute(
+        select(RadGroupReply).where(RadGroupReply.groupname == groupname)
+    )
+    check_result = await db.execute(
+        select(RadGroupCheck).where(RadGroupCheck.groupname == groupname)
+    )
+
+    replies = reply_result.scalars().all()
+    checks = check_result.scalars().all()
+
+    if not replies and not checks:
+        raise HTTPException(status_code=404, detail="Group not found")
+
+    return {
+        "groupname": groupname,
+        "replies": [
+            {"id": r.id, "attribute": r.attribute, "op": r.op, "value": r.value}
+            for r in replies
+        ],
+        "checks": [
+            {"id": c.id, "attribute": c.attribute, "op": c.op, "value": c.value}
+            for c in checks
+        ],
+    }
+
+
+@router.put("/rename", response_model=None)
+async def rename_group(
+    old_groupname: str,
+    new_groupname: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: AdminUser = require_roles(Role.SUPERADMIN, Role.ADMIN),
+):
+    """Rename a group - updates all references in reply, check, and usergroup tables."""
+    if not new_groupname or not old_groupname:
+        raise HTTPException(status_code=400, detail="Group names required")
+
+    # Check if old group exists
+    reply_result = await db.execute(
+        select(RadGroupReply).where(RadGroupReply.groupname == old_groupname)
+    )
+    check_result = await db.execute(
+        select(RadGroupCheck).where(RadGroupCheck.groupname == old_groupname)
+    )
+    user_result = await db.execute(
+        select(RadUserGroup).where(RadUserGroup.groupname == old_groupname)
+    )
+
+    if not (
+        reply_result.scalars().first()
+        or check_result.scalars().first()
+        or user_result.scalars().first()
+    ):
+        raise HTTPException(status_code=404, detail="Group not found")
+
+    # Update all references
+    await db.execute(
+        RadGroupReply.__table__.update()
+        .where(RadGroupReply.groupname == old_groupname)
+        .values(groupname=new_groupname)
+    )
+    await db.execute(
+        RadGroupCheck.__table__.update()
+        .where(RadGroupCheck.groupname == old_groupname)
+        .values(groupname=new_groupname)
+    )
+    await db.execute(
+        RadUserGroup.__table__.update()
+        .where(RadUserGroup.groupname == old_groupname)
+        .values(groupname=new_groupname)
+    )
+
+    await db.commit()
+    await log_audit(
+        db,
+        current_user.username,
+        "RENAME",
+        "group",
+        old_groupname,
+        old_value={"old_name": old_groupname},
+        new_value={"new_name": new_groupname},
+        event_code=EventCode.ADMIN_006,
+    )
+
+    return {
+        "ok": True,
+        "message": f"Group renamed from {old_groupname} to {new_groupname}",
+    }

--- a/backend/tests/integration/test_groups.py
+++ b/backend/tests/integration/test_groups.py
@@ -225,3 +225,76 @@ class TestGroupsUpdate:
             headers={"Authorization": f"Bearer {readonly_token}"},
         )
         assert resp.status_code == 403
+
+
+class TestGroupsManagement:
+    """Group management endpoints: rename and by-name."""
+
+    async def test_get_group_by_name(self, async_client, superadmin_token):
+        # First create a reply
+        create_payload = {
+            "groupname": "test_mgmt_group",
+            "attribute": "Service-Type",
+            "op": ":=",
+            "value": "NAS-Prompt-User",
+        }
+        await async_client.post(
+            "/groups/reply",
+            json=create_payload,
+            headers={"Authorization": f"Bearer {superadmin_token}"},
+        )
+
+        # Now get it by name
+        resp = await async_client.get(
+            "/groups/by-name/test_mgmt_group",
+            headers={"Authorization": f"Bearer {superadmin_token}"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["groupname"] == "test_mgmt_group"
+        assert len(data["replies"]) == 1
+        assert data["replies"][0]["attribute"] == "Service-Type"
+
+    async def test_rename_group(self, async_client, superadmin_token):
+        # First create a reply
+        create_payload = {
+            "groupname": "test_old_name",
+            "attribute": "Service-Type",
+            "op": ":=",
+            "value": "NAS-Prompt-User",
+        }
+        await async_client.post(
+            "/groups/reply",
+            json=create_payload,
+            headers={"Authorization": f"Bearer {superadmin_token}"},
+        )
+
+        # Now rename it
+        resp = await async_client.put(
+            "/groups/rename?old_groupname=test_old_name&new_groupname=test_new_name",
+            headers={"Authorization": f"Bearer {superadmin_token}"},
+        )
+        assert resp.status_code == 200
+        assert "renamed" in resp.json()["message"]
+
+        # Verify it's gone under old name
+        get_resp = await async_client.get(
+            "/groups/by-name/test_old_name",
+            headers={"Authorization": f"Bearer {superadmin_token}"},
+        )
+        assert get_resp.status_code == 404
+
+        # Verify it exists under new name
+        get_resp2 = await async_client.get(
+            "/groups/by-name/test_new_name",
+            headers={"Authorization": f"Bearer {superadmin_token}"},
+        )
+        assert get_resp2.status_code == 200
+        assert get_resp2.json()["groupname"] == "test_new_name"
+
+    async def test_helpdesk_cannot_rename_group(self, async_client, helpdesk_token):
+        resp = await async_client.put(
+            "/groups/rename?old_groupname=test&new_groupname=test2",
+            headers={"Authorization": f"Bearer {helpdesk_token}"},
+        )
+        assert resp.status_code == 403

--- a/frontend/src/pages/Policies.jsx
+++ b/frontend/src/pages/Policies.jsx
@@ -1,7 +1,8 @@
 import React, { useState, useMemo } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import api from '../api';
-import { Plus, Trash2, ArrowRight, X, Search, FileText, ShieldAlert, Cpu, Save, Play, RefreshCw, Box } from 'lucide-react';
+import GroupsService from '../services/groups';
+import { Plus, Trash2, ArrowRight, X, Search, FileText, ShieldAlert, Cpu, Save, Play, RefreshCw, Box, Edit2, Folder } from 'lucide-react';
 
 // --- SUB-COMPONENT: ATTRIBUTE SELECTOR ---
 const AttributeSelector = ({ dictionary, onSelect }) => {
@@ -103,6 +104,103 @@ const PoliciesPage = () => {
     // Compile state tracking
     const [compileStatus, setCompileStatus] = useState({ id: null, msg: '', error: false });
 
+    // Tab system: Macros vs Grupos RADIUS
+    const [activeTab, setActiveTab] = useState('macros'); // 'macros' or 'grupos'
+    const [selectedGroup, setSelectedGroup] = useState(null);
+    const [groupSearchQuery, setGroupSearchQuery] = useState('');
+    const [isEditGroupModalOpen, setIsEditGroupModalOpen] = useState(false);
+    const [groupFormData, setGroupFormData] = useState({ oldName: '', newName: '' });
+    const [isAttributeModalOpen, setIsAttributeModalOpen] = useState(false);
+    const [attributeFormData, setAttributeFormData] = useState({
+        type: 'reply', // 'reply' or 'check'
+        groupname: '',
+        attribute: '',
+        op: ':=',
+        value: '',
+        editId: null
+    });
+    const [newGroupFormData, setNewGroupFormData] = useState({ groupname: '' });
+
+    // --- DATA FETCHING: GRUPOS RADIUS ---
+    const { data: rawGroups } = useQuery({
+        queryKey: ['groups', 'list'],
+        queryFn: () => api.get('/groups/list').then(r => r.data),
+        enabled: activeTab === 'grupos'
+    });
+
+    const { data: groupDetails } = useQuery({
+        queryKey: ['groups', 'by-name', selectedGroup],
+        queryFn: () => GroupsService.getGroupByName(selectedGroup),
+        enabled: activeTab === 'grupos' && !!selectedGroup
+    });
+
+    // Mutations for Grupos RADIUS
+    const renameGroupMutation = useMutation({
+        mutationFn: ({ oldName, newName }) => GroupsService.renameGroup(oldName, newName),
+        onSuccess: () => {
+            queryClient.invalidateQueries(['groups', 'list']);
+            setIsEditGroupModalOpen(false);
+            setGroupFormData({ oldName: '', newName: '' });
+            setSelectedGroup(groupFormData.newName);
+            alert('Grupo renombrado correctamente');
+        },
+        onError: (err) => alert(err.response?.data?.detail || 'Error al renombrar')
+    });
+
+    const deleteGroupReplyMutation = useMutation({
+        mutationFn: (id) => GroupsService.deleteGroupReply(id),
+        onSuccess: () => {
+            queryClient.invalidateQueries(['groups', 'by-name', selectedGroup]);
+        }
+    });
+
+    const deleteGroupCheckMutation = useMutation({
+        mutationFn: (id) => GroupsService.deleteGroupCheck(id),
+        onSuccess: () => {
+            queryClient.invalidateQueries(['groups', 'by-name', selectedGroup]);
+        }
+    });
+
+    const createGroupAttributeMutation = useMutation({
+        mutationFn: (data) => data.type === 'reply' 
+            ? GroupsService.createGroupReply(data) 
+            : GroupsService.createGroupCheck(data),
+        onSuccess: () => {
+            queryClient.invalidateQueries(['groups', 'by-name', selectedGroup]);
+            setIsAttributeModalOpen(false);
+            setAttributeFormData({ type: 'reply', groupname: '', attribute: '', op: ':=', value: '', editId: null });
+        },
+        onError: (err) => alert(err.response?.data?.detail || 'Error al crear atributo')
+    });
+
+    const updateGroupAttributeMutation = useMutation({
+        mutationFn: ({ id, type, data }) => type === 'reply' 
+            ? GroupsService.updateGroupReply(id, data) 
+            : GroupsService.updateGroupCheck(id, data),
+        onSuccess: () => {
+            queryClient.invalidateQueries(['groups', 'by-name', selectedGroup]);
+            setIsAttributeModalOpen(false);
+            setAttributeFormData({ type: 'reply', groupname: '', attribute: '', op: ':=', value: '', editId: null });
+        },
+        onError: (err) => alert(err.response?.data?.detail || 'Error al actualizar atributo')
+    });
+
+    const createGroupMutation = useMutation({
+        mutationFn: async (groupname) => {
+            await GroupsService.createGroupReply({
+                groupname,
+                attribute: 'Description',
+                op: ':=',
+                value: 'Created via UI'
+            });
+        },
+        onSuccess: () => {
+            queryClient.invalidateQueries(['groups', 'list']);
+            alert('Grupo creado');
+        },
+        onError: (err) => alert(err.response?.data?.detail || 'Error al crear grupo')
+    });
+
     // --- DATA FETCHING ---
     const { data: macros, isLoading: macrosLoading } = useQuery({ 
         queryKey: ['iam', 'macros'], 
@@ -198,32 +296,51 @@ const PoliciesPage = () => {
     if (viewMode === 'list') {
         return (
             <div className="space-y-6 animate-fadeIn">
-                <div className="flex justify-between items-center bg-white p-6 rounded-lg shadow-sm border border-slate-200">
-                    <div>
-                        <h2 className="text-2xl font-black text-slate-800">Macro Policy Builder</h2>
-                        <p className="text-sm text-slate-500">Diseñador visual de plantillas NAC de FreeRADIUS.</p>
-                    </div>
+                {/* TABS: Macros vs Grupos RADIUS */}
+                <div className="bg-white rounded-lg shadow-sm border border-slate-200 p-1 flex gap-1">
                     <button
-                        onClick={() => setIsCreateModalOpen(true)}
-                        className="bg-indigo-600 text-white px-5 py-2 rounded-lg flex items-center gap-2 hover:bg-indigo-700 shadow font-bold"
+                        onClick={() => { setActiveTab('macros'); setSelectedGroup(null); }}
+                        className={`flex-1 py-3 px-4 rounded-md font-bold text-sm transition-colors flex items-center justify-center gap-2 ${activeTab === 'macros' ? 'bg-indigo-600 text-white shadow' : 'text-slate-500 hover:bg-slate-50'}`}
                     >
-                        <Plus size={18} /> Nueva Macro
+                        <Box size={18} /> Macros (IAM/NAC)
+                    </button>
+                    <button
+                        onClick={() => { setActiveTab('grupos'); setViewMode('list'); }}
+                        className={`flex-1 py-3 px-4 rounded-md font-bold text-sm transition-colors flex items-center justify-center gap-2 ${activeTab === 'grupos' ? 'bg-indigo-600 text-white shadow' : 'text-slate-500 hover:bg-slate-50'}`}
+                    >
+                        <Folder size={18} /> Grupos RADIUS
                     </button>
                 </div>
 
-                <div className="flex gap-4 items-center">
-                    <div className="relative flex-1 max-w-md">
-                        <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" size={18} />
-                        <input
-                            className="w-full pl-10 pr-4 py-3 border rounded-lg focus:ring-2 focus:ring-indigo-500 outline-none shadow-sm"
-                            placeholder="Buscar Macros por nombre..."
-                            value={searchQuery}
-                            onChange={(e) => setSearchQuery(e.target.value)}
-                        />
-                    </div>
-                </div>
+                {/* TAB CONTENT */}
+                {activeTab === 'macros' ? (
+                    <>
+                        <div className="flex justify-between items-center bg-white p-6 rounded-lg shadow-sm border border-slate-200">
+                            <div>
+                                <h2 className="text-2xl font-black text-slate-800">Macro Policy Builder</h2>
+                                <p className="text-sm text-slate-500">Diseñador visual de plantillas NAC de FreeRADIUS.</p>
+                            </div>
+                            <button
+                                onClick={() => setIsCreateModalOpen(true)}
+                                className="bg-indigo-600 text-white px-5 py-2 rounded-lg flex items-center gap-2 hover:bg-indigo-700 shadow font-bold"
+                            >
+                                <Plus size={18} /> Nueva Macro
+                            </button>
+                        </div>
 
-                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                        <div className="flex gap-4 items-center">
+                            <div className="relative flex-1 max-w-md">
+                                <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" size={18} />
+                                <input
+                                    className="w-full pl-10 pr-4 py-3 border rounded-lg focus:ring-2 focus:ring-indigo-500 outline-none shadow-sm"
+                                    placeholder="Buscar Macros por nombre..."
+                                    value={searchQuery}
+                                    onChange={(e) => setSearchQuery(e.target.value)}
+                                />
+                            </div>
+                        </div>
+
+                        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                     {filteredMacros.map(m => (
                         <div key={m.id} className="bg-white rounded-xl shadow border p-5 hover:shadow-lg transition-shadow border-t-4 border-t-indigo-500 relative group">
                             <h3 className="text-lg font-bold text-slate-800 flex items-center gap-2">
@@ -312,11 +429,212 @@ const PoliciesPage = () => {
                         </div>
                     </div>
                 )}
+            </>
+                ) : (
+                    /* ======================== TAB: GRUPOS RADIUS ======================== */
+                    <>
+                        <div className="flex justify-between items-center bg-white p-6 rounded-lg shadow-sm border border-slate-200">
+                            <div>
+                                <h2 className="text-2xl font-black text-slate-800">Grupos RADIUS</h2>
+                                <p className="text-sm text-slate-500">Gestión directa de grupos FreeRADIUS (radgroupreply, radgroupcheck).</p>
+                            </div>
+                            <button
+                                onClick={() => { setAttributeFormData({ type: 'reply', groupname: selectedGroup || '', attribute: '', op: ':=', value: '', editId: null }); setIsAttributeModalOpen(true); }}
+                                disabled={!selectedGroup}
+                                className="bg-indigo-600 text-white px-5 py-2 rounded-lg flex items-center gap-2 hover:bg-indigo-700 shadow font-bold disabled:opacity-50 disabled:cursor-not-allowed"
+                            >
+                                <Plus size={18} /> Agregar Atributo
+                            </button>
+                        </div>
+
+                        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+                            {/* Group List Sidebar */}
+                            <div className="bg-white rounded-xl shadow border p-4">
+                                <h3 className="text-sm font-black text-slate-500 uppercase tracking-widest mb-3">Grupos Existentes</h3>
+                                <div className="relative mb-3">
+                                    <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" size={16} />
+                                    <input
+                                        className="w-full pl-9 pr-4 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-indigo-500 outline-none"
+                                        placeholder="Buscar grupo..."
+                                        value={groupSearchQuery}
+                                        onChange={(e) => setGroupSearchQuery(e.target.value)}
+                                    />
+                                </div>
+                                <div className="space-y-1 max-h-[400px] overflow-y-auto">
+                                    {(rawGroups || []).filter(g => !groupSearchQuery || g.groupname.toLowerCase().includes(groupSearchQuery.toLowerCase())).map(g => (
+                                        <div key={g.groupname} className={`p-3 rounded-lg cursor-pointer transition-colors flex items-center justify-between ${selectedGroup === g.groupname ? 'bg-indigo-50 border border-indigo-200' : 'hover:bg-slate-50 border border-transparent'}`}>
+                                            <div onClick={() => setSelectedGroup(g.groupname)} className="flex-1">
+                                                <div className="font-bold text-sm text-slate-700">{g.groupname}</div>
+                                            </div>
+                                            <button
+                                                onClick={(e) => { e.stopPropagation(); setGroupFormData({ oldName: g.groupname, newName: g.groupname }); setIsEditGroupModalOpen(true); }}
+                                                className="p-1.5 text-slate-400 hover:text-indigo-600 hover:bg-indigo-50 rounded"
+                                                title="Renombrar"
+                                            >
+                                                <Edit2 size={14} />
+                                            </button>
+                                        </div>
+                                    ))}
+                                    {(!rawGroups || rawGroups.length === 0) && (
+                                        <div className="text-center text-gray-400 text-sm py-4">No hay grupos definidos</div>
+                                    )}
+                                </div>
+                            </div>
+
+                            {/* Group Details Panel */}
+                            <div className="col-span-2 bg-white rounded-xl shadow border p-4">
+                                {selectedGroup ? (
+                                    <>
+                                        <div className="flex justify-between items-center mb-4">
+                                            <h3 className="text-lg font-black text-slate-800">{selectedGroup}</h3>
+                                            <button
+                                                onClick={() => { if(window.confirm('¿Eliminar grupo completo?')) { /* TODO: delete entire group */ } }}
+                                                className="text-rose-500 hover:bg-rose-50 p-2 rounded"
+                                                title="Eliminar Grupo"
+                                            >
+                                                <Trash2 size={18} />
+                                            </button>
+                                        </div>
+
+                                        {/* Reply Attributes */}
+                                        <div className="mb-6">
+                                            <h4 className="text-sm font-black text-slate-500 uppercase tracking-widest mb-2 flex items-center gap-2">
+                                                <ShieldAlert size={14} className="text-emerald-600"/> Atributos de Respuesta (Reply)
+                                            </h4>
+                                            <div className="border rounded-lg overflow-hidden">
+                                                <div className="bg-slate-100 p-2 grid grid-cols-12 gap-2 text-xs font-black text-slate-500">
+                                                    <div className="col-span-4">Atributo</div>
+                                                    <div className="col-span-2 text-center">Op</div>
+                                                    <div className="col-span-5">Valor</div>
+                                                    <div className="col-span-1"></div>
+                                                </div>
+                                                <div className="divide-y">
+                                                    {(groupDetails?.replies || []).map(r => (
+                                                        <div key={r.id} className="p-2 grid grid-cols-12 gap-2 items-center text-sm hover:bg-slate-50">
+                                                            <div className="col-span-4 font-mono text-slate-700">{r.attribute}</div>
+                                                            <div className="col-span-2 text-center"><span className="bg-indigo-50 text-indigo-700 px-2 py-0.5 rounded font-mono text-xs">{r.op}</span></div>
+                                                            <div className="col-span-5 font-mono text-slate-600 truncate" title={r.value}>{r.value}</div>
+                                                            <div className="col-span-1 flex gap-1 justify-end">
+                                                                <button onClick={() => { setAttributeFormData({ type: 'reply', groupname: selectedGroup, attribute: r.attribute, op: r.op, value: r.value, editId: r.id }); setIsAttributeModalOpen(true); }} className="p-1 text-slate-400 hover:text-indigo-600"><Edit2 size={14} /></button>
+                                                                <button onClick={() => deleteGroupReplyMutation.mutate(r.id)} className="p-1 text-slate-400 hover:text-rose-500"><Trash2 size={14} /></button>
+                                                            </div>
+                                                        </div>
+                                                    ))}
+                                                    {(groupDetails?.replies || []).length === 0 && <div className="p-4 text-center text-gray-400 text-sm">Sin atributos de respuesta</div>}
+                                                </div>
+                                            </div>
+                                        </div>
+
+                                        {/* Check Attributes */}
+                                        <div>
+                                            <h4 className="text-sm font-black text-slate-500 uppercase tracking-widest mb-2 flex items-center gap-2">
+                                                <Search size={14} className="text-amber-600"/> Atributos de Verificación (Check)
+                                            </h4>
+                                            <div className="border rounded-lg overflow-hidden">
+                                                <div className="bg-slate-100 p-2 grid grid-cols-12 gap-2 text-xs font-black text-slate-500">
+                                                    <div className="col-span-4">Atributo</div>
+                                                    <div className="col-span-2 text-center">Op</div>
+                                                    <div className="col-span-5">Valor</div>
+                                                    <div className="col-span-1"></div>
+                                                </div>
+                                                <div className="divide-y">
+                                                    {(groupDetails?.checks || []).map(c => (
+                                                        <div key={c.id} className="p-2 grid grid-cols-12 gap-2 items-center text-sm hover:bg-slate-50">
+                                                            <div className="col-span-4 font-mono text-slate-700">{c.attribute}</div>
+                                                            <div className="col-span-2 text-center"><span className="bg-amber-50 text-amber-700 px-2 py-0.5 rounded font-mono text-xs">{c.op}</span></div>
+                                                            <div className="col-span-5 font-mono text-slate-600 truncate" title={c.value}>{c.value}</div>
+                                                            <div className="col-span-1 flex gap-1 justify-end">
+                                                                <button onClick={() => { setAttributeFormData({ type: 'check', groupname: selectedGroup, attribute: c.attribute, op: c.op, value: c.value, editId: c.id }); setIsAttributeModalOpen(true); }} className="p-1 text-slate-400 hover:text-indigo-600"><Edit2 size={14} /></button>
+                                                                <button onClick={() => deleteGroupCheckMutation.mutate(c.id)} className="p-1 text-slate-400 hover:text-rose-500"><Trash2 size={14} /></button>
+                                                            </div>
+                                                        </div>
+                                                    ))}
+                                                    {(groupDetails?.checks || []).length === 0 && <div className="p-4 text-center text-gray-400 text-sm">Sin atributos de verificación</div>}
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </>
+                                ) : (
+                                    <div className="text-center text-gray-400 py-12">
+                                        <Folder size={48} className="mx-auto text-gray-200 mb-3" />
+                                        <p className="font-bold">Seleccioná un grupo de la lista</p>
+                                        <p className="text-sm">para ver y editar sus atributos</p>
+                                    </div>
+                                )}
+                            </div>
+                        </div>
+
+                        {/* Rename Group Modal */}
+                        {isEditGroupModalOpen && (
+                            <div className="fixed inset-0 bg-slate-900/40 backdrop-blur-sm flex items-center justify-center p-4 z-50">
+                                <div className="bg-white rounded-xl p-6 w-full max-w-md shadow-2xl">
+                                    <h3 className="text-xl font-black mb-4 text-slate-800 flex items-center gap-2"><Edit2 className="text-indigo-600"/> Renombrar Grupo</h3>
+                                    <div>
+                                        <label className="text-xs font-black text-slate-500 uppercase">Nombre Actual</label>
+                                        <input className="w-full mt-1 border rounded-lg p-3 bg-slate-100 font-mono" value={groupFormData.oldName} disabled />
+                                    </div>
+                                    <div className="mt-3">
+                                        <label className="text-xs font-black text-slate-500 uppercase">Nuevo Nombre</label>
+                                        <input
+                                            className="w-full mt-1 border rounded-lg p-3 outline-none focus:ring-2 focus:ring-indigo-500"
+                                            value={groupFormData.newName}
+                                            onChange={(e) => setGroupFormData({ ...groupFormData, newName: e.target.value.replace(/\s+/g, '_') })}
+                                        />
+                                    </div>
+                                    <div className="flex gap-2 justify-end pt-4 border-t mt-4">
+                                        <button type="button" onClick={() => setIsEditGroupModalOpen(false)} className="px-4 py-2 text-gray-500 hover:bg-gray-100 rounded-lg font-bold">Cancelar</button>
+                                        <button type="button" onClick={() => renameGroupMutation.mutate({ oldName: groupFormData.oldName, newName: groupFormData.newName })} className="px-6 py-2 bg-indigo-600 text-white font-black rounded-lg">Guardar</button>
+                                    </div>
+                                </div>
+                            </div>
+                        )}
+
+                        {/* Add/Edit Attribute Modal */}
+                        {isAttributeModalOpen && (
+                            <div className="fixed inset-0 bg-slate-900/40 backdrop-blur-sm flex items-center justify-center p-4 z-50">
+                                <div className="bg-white rounded-xl p-6 w-full max-w-md shadow-2xl">
+                                    <h3 className="text-xl font-black mb-4 text-slate-800 flex items-center gap-2">
+                                        {attributeFormData.editId ? <Edit2 className="text-indigo-600"/> : <Plus className="text-indigo-600"/>}
+                                        {attributeFormData.editId ? 'Editar' : 'Agregar'} Atributo
+                                    </h3>
+                                    <form onSubmit={(e) => { e.preventDefault(); if(attributeFormData.editId) { updateGroupAttributeMutation.mutate({ id: attributeFormData.editId, type: attributeFormData.type, data: attributeFormData }); } else { createGroupAttributeMutation.mutate(attributeFormData); }}} className="space-y-3">
+                                        <div>
+                                            <label className="text-xs font-black text-slate-500 uppercase">Tipo</label>
+                                            <select className="w-full mt-1 border rounded-lg p-2" value={attributeFormData.type} onChange={(e) => setAttributeFormData({ ...attributeFormData, type: e.target.value })}>
+                                                <option value="reply">Reply (Respuesta)</option>
+                                                <option value="check">Check (Verificación)</option>
+                                            </select>
+                                        </div>
+                                        <div>
+                                            <label className="text-xs font-black text-slate-500 uppercase">Atributo</label>
+                                            <input className="w-full mt-1 border rounded-lg p-2 outline-none focus:ring-2 focus:ring-indigo-500" placeholder="Ej: Service-Type" value={attributeFormData.attribute} onChange={(e) => setAttributeFormData({ ...attributeFormData, attribute: e.target.value })} required />
+                                        </div>
+                                        <div>
+                                            <label className="text-xs font-black text-slate-500 uppercase">Operador</label>
+                                            <select className="w-full mt-1 border rounded-lg p-2" value={attributeFormData.op} onChange={(e) => setAttributeFormData({ ...attributeFormData, op: e.target.value })}>
+                                                <option value=":=">:=</option>
+                                                <option value="=">=</option>
+                                                <option value="==">==</option>
+                                                <option value="+=">+=</option>
+                                            </select>
+                                        </div>
+                                        <div>
+                                            <label className="text-xs font-black text-slate-500 uppercase">Valor</label>
+                                            <input className="w-full mt-1 border rounded-lg p-2 outline-none focus:ring-2 focus:ring-indigo-500" placeholder="Valor" value={attributeFormData.value} onChange={(e) => setAttributeFormData({ ...attributeFormData, value: e.target.value })} required />
+                                        </div>
+                                        <div className="flex gap-2 justify-end pt-3 border-t">
+                                            <button type="button" onClick={() => setIsAttributeModalOpen(false)} className="px-4 py-2 text-gray-500 hover:bg-gray-100 rounded-lg font-bold">Cancelar</button>
+                                            <button type="submit" className="px-6 py-2 bg-indigo-600 text-white font-black rounded-lg">{attributeFormData.editId ? 'Actualizar' : 'Agregar'}</button>
+                                        </div>
+                                    </form>
+                                </div>
+                            </div>
+                        )}
+                    </>
+                )}
             </div>
         );
     }
-
-    // --- VIEW: EDIT (BUILDER) ---
     if (!activeMacro) return null;
     const currentAttributes = activeMacro.attributes_json?.attributes || [];
 

--- a/frontend/src/services/groups.js
+++ b/frontend/src/services/groups.js
@@ -32,6 +32,54 @@ const GroupsService = {
     getGroupMembers: async (groupname) => {
         const response = await api.get(`/groups/members/${groupname}`);
         return response.data;
+    },
+
+    // Get group by name (replies + checks)
+    getGroupByName: async (groupname) => {
+        const response = await api.get(`/groups/by-name/${groupname}`);
+        return response.data;
+    },
+
+    // Rename a group
+    renameGroup: async (oldGroupname, newGroupname) => {
+        const response = await api.put(`/groups/rename?old_groupname=${oldGroupname}&new_groupname=${newGroupname}`);
+        return response.data;
+    },
+
+    // Update group reply attribute
+    updateGroupReply: async (id, data) => {
+        const response = await api.put(`/groups/reply/${id}`, data);
+        return response.data;
+    },
+
+    // Update group check attribute
+    updateGroupCheck: async (id, data) => {
+        const response = await api.put(`/groups/check/${id}`, data);
+        return response.data;
+    },
+
+    // Delete group reply attribute
+    deleteGroupReply: async (id) => {
+        const response = await api.delete(`/groups/reply/${id}`);
+        return response.data;
+    },
+
+    // Delete group check attribute
+    deleteGroupCheck: async (id) => {
+        const response = await api.delete(`/groups/check/${id}`);
+        return response.data;
+    },
+
+    // Create group reply attribute
+    createGroupReply: async (data) => {
+        const response = await api.post('/groups/reply', data);
+        return response.data;
+    },
+
+    // Create group check attribute
+    createGroupCheck: async (data) => {
+        const response = await api.post('/groups/check', data);
+        return response.data;
     }
 };
 


### PR DESCRIPTION
## Summary

Add complete CRUD for RADIUS groups directly from the UI.

### Backend Changes
- `GET /groups/by-name/{groupname}` - Get all reply/check attributes for a group
- `PUT /groups/rename` - Rename a group (updates all references)
- Integration tests for new endpoints

### Frontend Changes
- Add "Grupos RADIUS" tab to Policies.jsx
- List all raw RADIUS groups (from radgroupreply/radgroupcheck)
- View group attributes (reply and check tables)
- Add/edit/delete attributes
- Rename groups

### Files Changed
- `backend/app/routers/groups.py`
- `backend/tests/integration/test_groups.py`
- `frontend/src/pages/Policies.jsx`
- `frontend/src/services/groups.js`