### PR TITLE
feat(device-registry): add device registry with bulk CSV import and template download

### DIFF
--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import (
+﻿from sqlalchemy import (
     Column,
     Integer,
     BigInteger,
@@ -14,18 +14,37 @@ from sqlalchemy import (
     text,
 )
 from sqlalchemy.dialects.mysql import DATETIME as MySQLDATETIME
-from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.orm import Mapped, mapped_column, relationship, validates
 from sqlalchemy.sql import func
 from sqlalchemy.schema import FetchedValue
 from typing import Optional
 from app.db.session import Base
 import datetime
+import hashlib
+import ipaddress
+import re
 import secrets
+from sqlalchemy import event
 
 
 def _generate_secret() -> str:
     """Generate a random 48-character secret for NAS devices."""
     return secrets.token_urlsafe(36)
+
+
+_MAC_ACCEPTED_FORMATS = (
+    re.compile(r"^[0-9a-fA-F]{12}$"),
+    re.compile(r"^(?:[0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$"),
+    re.compile(r"^(?:[0-9a-fA-F]{2}-){5}[0-9a-fA-F]{2}$"),
+    re.compile(r"^(?:[0-9a-fA-F]{4}\.){2}[0-9a-fA-F]{4}$"),
+)
+
+
+def _normalize_mac(value: str) -> str:
+    """Validate exact supported MAC formats, then normalize to 12 lowercase hex."""
+    if not any(pattern.fullmatch(value) for pattern in _MAC_ACCEPTED_FORMATS):
+        raise ValueError("invalid MAC address format (must be 12 hex chars)")
+    return re.sub(r"[:.\-]", "", value).lower()
 
 
 class RadCheck(Base):
@@ -156,6 +175,13 @@ class RadAcct(Base):
     callingstationid: Mapped[str] = mapped_column(
         String(50), nullable=False, default=""
     )
+
+    @validates("callingstationid")
+    def validate_callingstationid(self, key, value):
+        if value is None:
+            return value
+        return _normalize_mac(value)
+
     acctterminatecause: Mapped[str] = mapped_column(
         String(32), nullable=False, default=""
     )
@@ -164,7 +190,7 @@ class RadAcct(Base):
     framedipaddress: Mapped[str] = mapped_column(
         String(15), nullable=False, default="", index=True
     )
-    # T08 — extended accounting fields (ISO 27001 A.8.15)
+    # T08 ÔÇö extended accounting fields (ISO 27001 A.8.15)
     nasidentifier: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
     privilege_level: Mapped[Optional[str]] = mapped_column(String(32), nullable=True)
     vendor_reply_attrs: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True)
@@ -181,7 +207,7 @@ class RadPostAuth(Base):
     authdate: Mapped[datetime.datetime] = mapped_column(
         MySQLDATETIME(fsp=6), server_default=func.now(), nullable=False
     )
-    # T07 — enhanced traceability fields (ISO 27001 A.8.15, A.5.33)
+    # T07 ÔÇö enhanced traceability fields (ISO 27001 A.8.15, A.5.33)
     nas_ip_address: Mapped[str] = mapped_column(String(15), nullable=False, default="")
     nas_identifier: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
     nas_port: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
@@ -220,11 +246,11 @@ class AdminUser(Base):
     force_password_change: Mapped[int] = mapped_column(
         Integer, default=1
     )  # 1=True, 0=False
-    # T03 — role column for RBAC (ISO 27001 A.5.15, A.5.18)
+    # T03 ÔÇö role column for RBAC (ISO 27001 A.5.15, A.5.18)
     role: Mapped[str] = mapped_column(String(32), nullable=False, default="admin")
 
 
-# T04 — LoginAttempt model for account lockout (ISO 27001 A.5.17)
+# T04 ÔÇö LoginAttempt model for account lockout (ISO 27001 A.5.17)
 class LoginAttempt(Base):
     __tablename__ = "login_attempts"
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
@@ -238,7 +264,7 @@ class LoginAttempt(Base):
     __table_args__ = (Index("idx_username_time", "username", "attempted_at"),)
 
 
-# T05 — RadiusReplyAudit model (ISO 27001 A.5.15, A.8.2, A.5.18)
+# T05 ÔÇö RadiusReplyAudit model (ISO 27001 A.5.15, A.8.2, A.5.18)
 class RadiusReplyAudit(Base):
     __tablename__ = "radius_reply_audit"
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
@@ -258,7 +284,7 @@ class RadiusReplyAudit(Base):
     record_hash: Mapped[Optional[str]] = mapped_column(String(71), nullable=True)
 
 
-# T06 — UserNasPrivilegeMap model (ISO 27001 A.5.15, A.8.2)
+# T06 ÔÇö UserNasPrivilegeMap model (ISO 27001 A.5.15, A.8.2)
 class UserNasPrivilegeMap(Base):
     __tablename__ = "user_nas_privilege_map"
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
@@ -377,6 +403,7 @@ class NasCategory(Base):
     )
 
     nases: Mapped[list["Nas"]] = relationship("Nas", back_populates="category")
+    devices: Mapped[list["DeviceRegistry"]] = relationship("DeviceRegistry", back_populates="category")
 
 
 # syslog-compliance: Phase 2 - SyslogEvent model with hash chain for integrity
@@ -401,3 +428,43 @@ class SyslogEvent(Base):
         Index("idx_syslog_severity", "severity"),
         Index("idx_syslog_facility", "facility"),
     )
+
+
+# --- Device Registry Domain Models ---
+
+
+class DeviceRegistry(Base):
+    """Known endpoint devices (SMs, CPEs) identified by MAC address.
+    Assigned to a NAS category so RADIUS can resolve device-level policies
+    without registering individual MACs in access_policy_assignments.
+    """
+
+    __tablename__ = "device_registry"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    mac: Mapped[str] = mapped_column(String(50), nullable=False, unique=True)
+    name: Mapped[Optional[str]] = mapped_column(String(120), nullable=True)
+    category_id: Mapped[Optional[int]] = mapped_column(
+        Integer,
+        ForeignKey("nas_categories.id", ondelete="SET NULL", name="fk_device_category"),
+        nullable=True,
+    )
+    category: Mapped[Optional["NasCategory"]] = relationship("NasCategory", back_populates="devices")
+    nas_ip: Mapped[Optional[str]] = mapped_column(String(50), nullable=True)
+    description: Mapped[Optional[str]] = mapped_column(String(200), nullable=True)
+    is_active: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    created_at: Mapped[Optional[datetime.datetime]] = mapped_column(
+        DateTime(timezone=False), server_default=func.now(), nullable=True
+    )
+    updated_at: Mapped[Optional[datetime.datetime]] = mapped_column(
+        DateTime(timezone=False),
+        server_default=text("CURRENT_TIMESTAMP(6)"),
+        server_onupdate=FetchedValue(),
+        nullable=True,
+    )
+
+    @validates("mac")
+    def normalize_mac(self, key, value):
+        if value is None:
+            return value
+        return _normalize_mac(value)

--- a/backend/app/routers/device_registry.py
+++ b/backend/app/routers/device_registry.py
@@ -1,0 +1,384 @@
+﻿"""
+Device Registry router ÔÇö device-registry feature
+CRUD + bulk import for endpoint devices (SMs, CPEs) identified by MAC.
+Supports CSV bulk upload and JSON bulk create.
+"""
+
+import csv
+import io
+import logging
+import ipaddress
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, UploadFile, File
+from sqlalchemy import select, func
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.requests import Request
+from starlette.responses import Response
+
+from app.core.limiter import limiter
+from app.core.rbac import require_roles, Role
+from app.core.security import get_current_active_user
+from app.db.session import get_db
+from app.models.models import AdminUser, DeviceRegistry, NasCategory
+from app.schemas.device_registry import (
+    DeviceRegistryCreate,
+    DeviceRegistryUpdate,
+    DeviceRegistryOut,
+    DeviceRegistryBulkCreate,
+    DeviceRegistryBulkResult,
+    _normalize_mac,
+)
+from app.services.audit import log_audit, EventCode
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/device-registry", tags=["device-registry"])
+
+
+def _validate_required_bulk_fields(*, mac: str, nas_ip: Optional[str], name: Optional[str], description: Optional[str], context: str):
+    if not mac:
+        raise ValueError(f"{context}: missing mac")
+    if nas_ip is None or not nas_ip.strip():
+        raise ValueError(f"{context}: missing nas_ip")
+    if name is None or not name.strip():
+        raise ValueError(f"{context}: missing name")
+    if description is None or not description.strip():
+        raise ValueError(f"{context}: missing description")
+
+    cleaned_ip = nas_ip.strip()
+    try:
+        ipaddress.ip_address(cleaned_ip)
+    except ValueError as exc:
+        raise ValueError(f"{context}: invalid nas_ip '{cleaned_ip}'") from exc
+
+    return cleaned_ip, name.strip(), description.strip()
+
+
+# ÔöÇÔöÇ helpers ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
+
+
+async def _get_or_404(db: AsyncSession, device_id: int) -> DeviceRegistry:
+    result = await db.execute(select(DeviceRegistry).where(DeviceRegistry.id == device_id))
+    device = result.scalars().first()
+    if not device:
+        raise HTTPException(status_code=404, detail="Device not found")
+    return device
+
+
+def _to_out(device: DeviceRegistry) -> DeviceRegistryOut:
+    out = DeviceRegistryOut.model_validate(device)
+    if device.category:
+        out.category_name = device.category.name
+    return out
+
+
+# ÔöÇÔöÇ routes ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ
+
+
+@router.get("", response_model=list[DeviceRegistryOut])
+@limiter.limit("60/minute")
+async def list_devices(
+    request: Request,
+    category_id: Optional[int] = Query(None),
+    nas_ip: Optional[str] = Query(None),
+    is_active: Optional[int] = Query(None),
+    db: AsyncSession = Depends(get_db),
+    current_user: AdminUser = Depends(get_current_active_user),
+):
+    q = select(DeviceRegistry)
+    if category_id is not None:
+        q = q.where(DeviceRegistry.category_id == category_id)
+    if nas_ip is not None:
+        q = q.where(DeviceRegistry.nas_ip == nas_ip)
+    if is_active is not None:
+        q = q.where(DeviceRegistry.is_active == is_active)
+    q = q.order_by(DeviceRegistry.id)
+
+    result = await db.execute(q)
+    devices = result.scalars().all()
+
+    # Eager load categories
+    out = []
+    for d in devices:
+        await db.refresh(d, ["category"])
+        out.append(_to_out(d))
+    return out
+
+
+@router.get("/stats")
+@limiter.limit("60/minute")
+async def device_stats(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    current_user: AdminUser = Depends(get_current_active_user),
+):
+    total = await db.scalar(select(func.count()).select_from(DeviceRegistry))
+    active = await db.scalar(
+        select(func.count()).select_from(DeviceRegistry).where(DeviceRegistry.is_active == 1)
+    )
+    return {"total": total, "active": active}
+
+
+@router.get("/{device_id}", response_model=DeviceRegistryOut)
+@limiter.limit("60/minute")
+async def get_device(
+    request: Request,
+    device_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: AdminUser = Depends(get_current_active_user),
+):
+    device = await _get_or_404(db, device_id)
+    await db.refresh(device, ["category"])
+    return _to_out(device)
+
+
+@router.post("", response_model=DeviceRegistryOut, status_code=201)
+@limiter.limit("30/minute")
+async def create_device(
+    request: Request,
+    payload: DeviceRegistryCreate,
+    db: AsyncSession = Depends(get_db),
+    current_user: AdminUser = require_roles(Role.ADMIN, Role.SUPERADMIN),
+):
+    if payload.category_id:
+        cat = await db.scalar(select(NasCategory).where(NasCategory.id == payload.category_id))
+        if not cat:
+            raise HTTPException(status_code=404, detail="Category not found")
+
+    device = DeviceRegistry(**payload.model_dump())
+    db.add(device)
+    try:
+        await db.commit()
+    except IntegrityError:
+        await db.rollback()
+        raise HTTPException(status_code=409, detail=f"MAC '{payload.mac}' already registered")
+    await db.refresh(device, ["category"])
+
+    await log_audit(db, current_user.username, "CREATE", "device_registry", payload.mac,
+                    new_value=payload.model_dump(), event_code=EventCode.ADMIN_005)
+    return _to_out(device)
+
+
+@router.put("/{device_id}", response_model=DeviceRegistryOut)
+@limiter.limit("30/minute")
+async def update_device(
+    request: Request,
+    device_id: int,
+    payload: DeviceRegistryUpdate,
+    db: AsyncSession = Depends(get_db),
+    current_user: AdminUser = require_roles(Role.ADMIN, Role.SUPERADMIN),
+):
+    device = await _get_or_404(db, device_id)
+
+    if payload.category_id is not None:
+        cat = await db.scalar(select(NasCategory).where(NasCategory.id == payload.category_id))
+        if not cat:
+            raise HTTPException(status_code=404, detail="Category not found")
+
+    for key, value in payload.model_dump(exclude_none=True).items():
+        setattr(device, key, value)
+
+    await db.commit()
+    await db.refresh(device, ["category"])
+
+    await log_audit(db, current_user.username, "UPDATE", "device_registry", device.mac,
+                    new_value=payload.model_dump(exclude_none=True))
+    return _to_out(device)
+
+
+@router.delete("/{device_id}")
+@limiter.limit("30/minute")
+async def delete_device(
+    request: Request,
+    device_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: AdminUser = require_roles(Role.SUPERADMIN),
+):
+    device = await _get_or_404(db, device_id)
+    mac = device.mac
+    await db.delete(device)
+    await db.commit()
+    await log_audit(db, current_user.username, "DELETE", "device_registry", mac)
+    return {"ok": True}
+
+
+@router.post("/bulk", response_model=DeviceRegistryBulkResult, status_code=200)
+@limiter.limit("10/minute")
+async def bulk_create(
+    request: Request,
+    payload: DeviceRegistryBulkCreate,
+    db: AsyncSession = Depends(get_db),
+    current_user: AdminUser = require_roles(Role.ADMIN, Role.SUPERADMIN),
+):
+    """Upsert multiple devices. Existing MACs are updated, new ones created."""
+    created = updated = 0
+    errors: list[str] = []
+
+    for item in payload.devices:
+        cat_id = item.category_id if item.category_id is not None else payload.category_id
+        try:
+            nas_ip, name, description = _validate_required_bulk_fields(
+                mac=item.mac,
+                nas_ip=item.nas_ip,
+                name=item.name,
+                description=item.description,
+                context=f"mac {item.mac}",
+            )
+            existing = await db.scalar(
+                select(DeviceRegistry).where(DeviceRegistry.mac == item.mac)
+            )
+            if existing:
+                existing.category_id = cat_id
+                existing.nas_ip = nas_ip
+                existing.name = name
+                existing.description = description
+                existing.is_active = item.is_active
+                updated += 1
+            else:
+                db.add(DeviceRegistry(
+                    mac=item.mac,
+                    category_id=cat_id,
+                    nas_ip=nas_ip,
+                    name=name,
+                    description=description,
+                    is_active=item.is_active,
+                ))
+                created += 1
+        except Exception as exc:
+            errors.append(f"{item.mac}: {exc}")
+
+    await db.commit()
+    await log_audit(db, current_user.username, "BULK_CREATE", "device_registry", "bulk",
+                    new_value={"created": created, "updated": updated, "errors": len(errors)})
+    return DeviceRegistryBulkResult(created=created, updated=updated, errors=errors)
+
+
+@router.post("/bulk/csv", response_model=DeviceRegistryBulkResult, status_code=200)
+@limiter.limit("10/minute")
+async def bulk_create_csv(
+    request: Request,
+    file: UploadFile = File(...),
+    default_category_id: Optional[int] = Query(None),
+    db: AsyncSession = Depends(get_db),
+    current_user: AdminUser = require_roles(Role.ADMIN, Role.SUPERADMIN),
+):
+    """
+    Upload CSV with columns: mac, nas_ip, name, description, category_id (optional).
+    Upserts all rows. Existing MACs are updated.
+    """
+    content = await file.read()
+    text = content.decode("utf-8-sig")  # handle BOM
+    reader = csv.DictReader(io.StringIO(text))
+
+    required_headers = {"mac", "nas_ip", "name", "description"}
+    csv_headers = set(reader.fieldnames or [])
+    missing_headers = sorted(required_headers - csv_headers)
+    if missing_headers:
+        raise HTTPException(
+            status_code=400,
+            detail=f"CSV missing required header(s): {', '.join(missing_headers)}",
+        )
+
+    created = updated = 0
+    errors: list[str] = []
+
+    for i, row in enumerate(reader, start=2):
+        raw_mac = (row.get("mac") or "").strip()
+        if not raw_mac:
+            errors.append(f"row {i}: missing mac")
+            continue
+
+        try:
+            mac = _normalize_mac(raw_mac)
+        except ValueError as exc:
+            errors.append(f"row {i} ({raw_mac}): {exc}")
+            continue
+
+        raw_cat = (row.get("category_id") or "").strip()
+        cat_id = int(raw_cat) if raw_cat.isdigit() else default_category_id
+        if cat_id is not None:
+            cat = await db.scalar(select(NasCategory).where(NasCategory.id == cat_id))
+            if not cat:
+                errors.append(f"row {i} ({mac}): category_id {cat_id} not found")
+                continue
+        nas_ip_raw = (row.get("nas_ip") or "").strip() or None
+        name_raw = (row.get("name") or "").strip() or None
+        description_raw = (row.get("description") or "").strip() or None
+
+        try:
+            nas_ip, name, description = _validate_required_bulk_fields(
+                mac=mac,
+                nas_ip=nas_ip_raw,
+                name=name_raw,
+                description=description_raw,
+                context=f"row {i}",
+            )
+        except ValueError as exc:
+            errors.append(str(exc))
+            continue
+
+        try:
+            existing = await db.scalar(select(DeviceRegistry).where(DeviceRegistry.mac == mac))
+            if existing:
+                existing.category_id = cat_id
+                existing.nas_ip = nas_ip
+                existing.name = name
+                existing.description = description
+                updated += 1
+            else:
+                db.add(DeviceRegistry(mac=mac, category_id=cat_id, nas_ip=nas_ip,
+                                      name=name, description=description))
+                created += 1
+        except Exception as exc:
+            errors.append(f"row {i} ({mac}): {exc}")
+
+    await db.commit()
+    await log_audit(db, current_user.username, "BULK_CSV", "device_registry", file.filename or "upload",
+                    new_value={"created": created, "updated": updated, "errors": len(errors)})
+    return DeviceRegistryBulkResult(created=created, updated=updated, errors=errors)
+
+
+@router.get("/bulk/template")
+@limiter.limit("30/minute")
+async def download_bulk_template(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    current_user: AdminUser = require_roles(Role.ADMIN, Role.SUPERADMIN),
+):
+    """
+    Generate a CSV template with columns: mac, name, description, category_id, nas_ip.
+    Use this template to bulk-import devices via /bulk/csv.
+    """
+    headers = ["mac", "name", "description", "category_id", "nas_ip"]
+    rows = [
+        ["0A:00:3E:45:76:4A", "SM Torre Norte", "Cliente premium - sector norte", "2", "192.168.1.11"],
+        ["0A:00:3E:45:76:4B", "SM Torre Sur", "Backhaul secundario", "", "192.168.1.12"],
+    ]
+
+    # Fetch categories for reference
+    result = await db.execute(select(NasCategory).order_by(NasCategory.name))
+    categories = result.scalars().all()
+
+    output = io.StringIO()
+    writer = csv.writer(output)
+
+    # Write data section with comment header
+    writer.writerow(["# Device Registry Bulk Import Template"])
+    writer.writerow(["# Columns: mac, name, description, category_id, nas_ip"])
+    writer.writerow(["# Supported MAC formats: 0A:00:3E:45:76:4A, 0A-00-3E-45-76-4A, 0A00.3E45.764A, 0A003E45764A (case-insensitive)"])
+    writer.writerow(["# MAC addresses will be normalized to lowercase 12-char hex (e.g. 0a003e45764a)"])
+    writer.writerow(["# Categories available:"] + [f"{c.id}={c.name}" for c in categories])
+    writer.writerow([])
+    writer.writerow(headers)
+    for row in rows:
+        writer.writerow(row)
+
+    csv_content = output.getvalue()
+
+    return Response(
+        content=csv_content.encode("utf-8-sig"),
+        media_type="text/csv",
+        headers={"Content-Disposition": "attachment; filename=device_registry_bulk_template.csv"},
+    )

--- a/backend/app/schemas/device_registry.py
+++ b/backend/app/schemas/device_registry.py
@@ -1,0 +1,111 @@
+﻿import re
+import ipaddress
+from typing import Optional
+from pydantic import BaseModel, ConfigDict, field_validator
+
+_MAC_ACCEPTED_FORMATS = (
+    re.compile(r"^[0-9a-fA-F]{12}$"),
+    re.compile(r"^(?:[0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$"),
+    re.compile(r"^(?:[0-9a-fA-F]{2}-){5}[0-9a-fA-F]{2}$"),
+    re.compile(r"^(?:[0-9a-fA-F]{4}\.){2}[0-9a-fA-F]{4}$"),
+)
+
+
+def _normalize_mac(value: str) -> str:
+    if not any(p.fullmatch(value) for p in _MAC_ACCEPTED_FORMATS):
+        raise ValueError(f"invalid MAC format: '{value}'")
+    return re.sub(r"[:.\-]", "", value).lower()
+
+
+class DeviceRegistryBase(BaseModel):
+    mac: str
+    name: Optional[str] = None
+    category_id: Optional[int] = None
+    nas_ip: Optional[str] = None
+    description: Optional[str] = None
+    is_active: int = 1
+
+    @field_validator("mac")
+    @classmethod
+    def validate_mac(cls, v: str) -> str:
+        return _normalize_mac(v.strip())
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return None
+        cleaned = v.strip()
+        return cleaned or None
+
+    @field_validator("nas_ip")
+    @classmethod
+    def validate_nas_ip(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return None
+        cleaned = v.strip()
+        if not cleaned:
+            return None
+        try:
+            ipaddress.ip_address(cleaned)
+        except ValueError as exc:
+            raise ValueError(f"invalid IP address: '{cleaned}'") from exc
+        return cleaned
+
+
+class DeviceRegistryCreate(DeviceRegistryBase):
+    pass
+
+
+class DeviceRegistryUpdate(BaseModel):
+    name: Optional[str] = None
+    category_id: Optional[int] = None
+    nas_ip: Optional[str] = None
+    description: Optional[str] = None
+    is_active: Optional[int] = None
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return None
+        cleaned = v.strip()
+        return cleaned or None
+
+    @field_validator("nas_ip")
+    @classmethod
+    def validate_nas_ip(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return None
+        cleaned = v.strip()
+        if not cleaned:
+            return None
+        try:
+            ipaddress.ip_address(cleaned)
+        except ValueError as exc:
+            raise ValueError(f"invalid IP address: '{cleaned}'") from exc
+        return cleaned
+
+
+class DeviceRegistryOut(DeviceRegistryBase):
+    id: int
+    category_name: Optional[str] = None
+    model_config = ConfigDict(from_attributes=True)
+
+
+class DeviceRegistryBulkCreate(BaseModel):
+    devices: list[DeviceRegistryCreate]
+    category_id: Optional[int] = None  # default category for all if not specified per device
+
+    @field_validator("devices")
+    @classmethod
+    def validate_not_empty(cls, v):
+        if not v:
+            raise ValueError("devices list cannot be empty")
+        return v
+
+
+class DeviceRegistryBulkResult(BaseModel):
+    created: int
+    updated: int
+    errors: list[str]

--- a/backend/tests/integration/test_device_registry.py
+++ b/backend/tests/integration/test_device_registry.py
@@ -1,0 +1,142 @@
+﻿import csv
+import io
+
+import pytest
+from httpx import AsyncClient
+
+
+pytestmark = pytest.mark.asyncio
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def test_bulk_template_returns_expected_xlsx(async_client: AsyncClient, admin_token: str):
+    resp = await async_client.get(
+        "/device-registry/bulk/template",
+        headers=_auth(admin_token),
+    )
+
+    assert resp.status_code == 200
+    assert (
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        in resp.headers.get("content-type", "")
+    )
+    assert (
+        "device_registry_bulk_template.xlsx"
+        in resp.headers.get("content-disposition", "")
+    )
+
+    import io as io_module
+    import openpyxl
+    wb = openpyxl.load_workbook(io_module.BytesIO(resp.content))
+    sheet_names = wb.sheetnames
+    assert len(sheet_names) == 2
+    assert "Template" in sheet_names
+    assert "Categories" in sheet_names
+
+
+async def test_bulk_json_accepts_required_fields_with_optional_category(async_client: AsyncClient, admin_token: str):
+    payload = {
+        "devices": [
+            {
+                "mac": "0A:00:3E:45:76:AA",
+                "nas_ip": "192.168.50.10",
+                "name": "SM Torre Norte",
+                "description": "Cliente premium",
+                "is_active": 1,
+            }
+        ]
+    }
+
+    resp = await async_client.post(
+        "/device-registry/bulk",
+        json=payload,
+        headers=_auth(admin_token),
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["created"] == 1
+    assert body["updated"] == 0
+    assert body["errors"] == []
+
+    listed = await async_client.get("/device-registry", headers=_auth(admin_token))
+    assert listed.status_code == 200
+    created = next((row for row in listed.json() if row["mac"] == "0a003e4576aa"), None)
+    assert created is not None
+    assert created["nas_ip"] == "192.168.50.10"
+    assert created["name"] == "SM Torre Norte"
+    assert created["description"] == "Cliente premium"
+    assert created["category_id"] is None
+
+
+async def test_bulk_json_rejects_missing_new_required_fields(async_client: AsyncClient, admin_token: str):
+    payload = {
+        "devices": [
+            {
+                "mac": "0A:00:3E:45:76:AB",
+                "nas_ip": "192.168.50.11",
+                "name": None,
+                "description": "Tiene IP pero no name",
+                "is_active": 1,
+            },
+            {
+                "mac": "0A:00:3E:45:76:AC",
+                "nas_ip": "",
+                "name": "SM Sin IP",
+                "description": "Falta nas_ip",
+                "is_active": 1,
+            },
+            {
+                "mac": "0A:00:3E:45:76:AD",
+                "nas_ip": "192.168.50.12",
+                "name": "SM Sin Descripci├│n",
+                "description": "",
+                "is_active": 1,
+            },
+        ]
+    }
+
+    resp = await async_client.post(
+        "/device-registry/bulk",
+        json=payload,
+        headers=_auth(admin_token),
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["created"] == 0
+    assert body["updated"] == 0
+    assert len(body["errors"]) == 3
+    assert any("missing name" in err for err in body["errors"])
+    assert any("missing nas_ip" in err for err in body["errors"])
+    assert any("missing description" in err for err in body["errors"])
+
+
+async def test_bulk_csv_valid_row_with_name_is_imported(async_client: AsyncClient, admin_token: str):
+    csv_payload = (
+        "mac,nas_ip,name,description,category_id\n"
+        "0A:00:3E:45:76:AE,192.168.60.10,SM CSV Norte,Importado por CSV,\n"
+    )
+    files = {"file": ("devices.csv", csv_payload, "text/csv")}
+
+    resp = await async_client.post(
+        "/device-registry/bulk/csv",
+        files=files,
+        headers=_auth(admin_token),
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["created"] == 1
+    assert body["updated"] == 0
+    assert body["errors"] == []
+
+    listed = await async_client.get("/device-registry", headers=_auth(admin_token))
+    assert listed.status_code == 200
+    created = next((row for row in listed.json() if row["mac"] == "0a003e4576ae"), None)
+    assert created is not None
+    assert created["name"] == "SM CSV Norte"
+    assert created["description"] == "Importado por CSV"

--- a/backend/tests/integration/test_device_registry_template.py
+++ b/backend/tests/integration/test_device_registry_template.py
@@ -1,0 +1,197 @@
+﻿"""Tests for device-registry bulk template CSV generation."""
+
+import io
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import delete
+
+
+pytestmark = pytest.mark.asyncio
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def test_bulk_template_returns_csv(
+    async_client: AsyncClient, admin_token: str
+):
+    """Template endpoint must return CSV Content-Type and .csv filename."""
+    resp = await async_client.get(
+        "/device-registry/bulk/template",
+        headers=_auth(admin_token),
+    )
+
+    assert resp.status_code == 200
+    assert (
+        "text/csv" in resp.headers.get("content-type", "")
+    ), f"Expected text/csv content-type, got: {resp.headers.get('content-type')}"
+    assert (
+        "device_registry_bulk_template.csv"
+        in resp.headers.get("content-disposition", "")
+    ), f"Expected .csv filename, got: {resp.headers.get('content-disposition')}"
+
+
+async def test_template_csv_has_correct_headers_and_example_rows(
+    async_client: AsyncClient, admin_token: str
+):
+    """CSV must have required headers: mac, name, description, category_id, nas_ip."""
+    resp = await async_client.get(
+        "/device-registry/bulk/template",
+        headers=_auth(admin_token),
+    )
+    assert resp.status_code == 200
+
+    text = resp.content.decode("utf-8-sig")
+
+    import csv
+    reader = csv.reader(io.StringIO(text))
+    rows = list(reader)
+
+    # Find the actual data header row (skip # comment lines)
+    data_header_idx = None
+    for i, row in enumerate(rows):
+        if row and not row[0].startswith("#"):
+            data_header_idx = i
+            break
+
+    assert data_header_idx is not None, "No data header found after comment lines"
+    headers = rows[data_header_idx]
+    assert headers == [
+        "mac",
+        "name",
+        "description",
+        "category_id",
+        "nas_ip",
+    ], f"CSV headers mismatch: {headers}"
+
+    # Example rows must be after header row
+    assert len(rows) > data_header_idx + 1, "No example rows found after header"
+
+    # Verify at least one example row has non-empty mac
+    example_rows = rows[data_header_idx + 1 :]
+    first_example = example_rows[0]
+    assert first_example[0] is not None and str(first_example[0]).strip() != "", (
+        "First example row must have a non-empty mac address"
+    )
+
+
+async def test_template_csv_contains_category_reference(
+    async_client: AsyncClient,
+    admin_token: str,
+    test_db,
+):
+    """CSV template must contain category reference in comment lines."""
+    from app.models.models import NasCategory
+
+    # Seed two categories
+    cat1 = NasCategory(name="Residential AP", description="Standard home routers")
+    cat2 = NasCategory(name="Enterprise AP", description="High-capacity sector")
+    test_db.add_all([cat1, cat2])
+    await test_db.commit()
+
+    try:
+        resp = await async_client.get(
+            "/device-registry/bulk/template",
+            headers=_auth(admin_token),
+        )
+        assert resp.status_code == 200
+
+        text = resp.content.decode("utf-8-sig")
+
+        # Should contain category reference comment
+        assert "Categories available:" in text, (
+            "CSV template must contain category reference comment"
+        )
+        assert "Residential AP" in text, "Category reference should include category name"
+        assert "Enterprise AP" in text, "Category reference should include category name"
+    finally:
+        await test_db.execute(
+            delete(NasCategory).where(NasCategory.name.in_(["Residential AP", "Enterprise AP"]))
+        )
+        await test_db.commit()
+
+
+async def test_template_csv_has_no_serial_number_field(
+    async_client: AsyncClient, admin_token: str
+):
+    """CSV template must NOT contain serial_number column ÔÇö MAC is the unique identifier."""
+    resp = await async_client.get(
+        "/device-registry/bulk/template",
+        headers=_auth(admin_token),
+    )
+    assert resp.status_code == 200
+
+    text = resp.content.decode("utf-8-sig")
+    lines = text.splitlines()
+
+    # Find the data header row
+    data_header_idx = None
+    for i, line in enumerate(lines):
+        if line.strip().startswith("#"):
+            continue
+        if line.strip():
+            data_header_idx = i
+            break
+
+    assert data_header_idx is not None
+
+    import csv
+    reader = csv.reader(io.StringIO(text))
+    rows = list(reader)
+    headers = rows[data_header_idx]
+
+    assert "serial_number" not in headers, (
+        f"CSV template must NOT have serial_number column, found headers: {headers}"
+    )
+
+
+async def test_bulk_csv_endpoint_normalizes_mac_formats(
+    async_client: AsyncClient, admin_token: str, test_db
+):
+    """MAC addresses in various formats should be normalized to lowercase 12-char hex."""
+    from app.models.models import DeviceRegistry
+
+    # Clean up any existing test devices
+    await test_db.execute(
+        delete(DeviceRegistry).where(
+            DeviceRegistry.mac.in_(["0a003e45764a", "1b003e45764b"])
+        )
+    )
+    await test_db.commit()
+
+    try:
+        # Upload CSV with mixed MAC formats (all required fields provided)
+        csv_content = """mac,name,description,category_id,nas_ip
+0A:00:3E:45:76:4A,Device Colons,Test device colons,,192.168.1.10
+1B-00-3E-45-76-4B,Device Dashes,Test device dashes,,192.168.1.11
+1c00.3e45.764c,Device Dots,Test device dots,,192.168.1.12
+1D003E45764D,Device Plain,Test device plain,,192.168.1.13
+"""
+        resp = await async_client.post(
+            "/device-registry/bulk/csv",
+            headers=_auth(admin_token),
+            files={"file": ("devices.csv", csv_content.encode("utf-8"), "text/csv")},
+        )
+        assert resp.status_code == 200
+        result = resp.json()
+        assert result["created"] == 4, f"Expected 4 created, got {result}"
+        assert len(result["errors"]) == 0, f"Unexpected errors: {result['errors']}"
+
+        # Verify all MACs were normalized to lowercase 12-char hex
+        from sqlalchemy import select
+
+        for normalized_mac in ["0a003e45764a", "1b003e45764b", "1c003e45764c", "1d003e45764d"]:
+            result_row = await test_db.execute(
+                select(DeviceRegistry).where(DeviceRegistry.mac == normalized_mac)
+            )
+            device = result_row.scalars().first()
+            assert device is not None, f"MAC {normalized_mac} not found in DB ÔÇö normalization failed"
+    finally:
+        await test_db.execute(
+            delete(DeviceRegistry).where(
+                DeviceRegistry.mac.in_(["0a003e45764a", "1b003e45764b", "1c003e45764c", "1d003e45764d"])
+            )
+        )
+        await test_db.commit()

--- a/database/migrations/008_device_registry.sql
+++ b/database/migrations/008_device_registry.sql
@@ -1,0 +1,25 @@
+﻿-- Migration 008: Device Registry
+-- Stores known endpoint devices (SMs, CPEs, etc.) by MAC with a category assignment.
+-- Enables RADIUS Step 1.5: resolve Calling-Station-Id ÔåÆ device category ÔåÆ user policy.
+-- Solves the 1000+ SM problem: register MACs once here, policy map references category only.
+
+START TRANSACTION;
+
+CREATE TABLE IF NOT EXISTS device_registry (
+    id              INT AUTO_INCREMENT PRIMARY KEY,
+    mac             VARCHAR(50)  NOT NULL,
+    category_id     INT          NULL DEFAULT NULL,
+    nas_ip          VARCHAR(50)  NULL DEFAULT NULL,
+    description     VARCHAR(200) NULL DEFAULT NULL,
+    is_active       TINYINT(1)   NOT NULL DEFAULT 1,
+    created_at      DATETIME(6)  DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at      DATETIME(6)  DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    UNIQUE KEY uq_device_mac (mac),
+    INDEX idx_device_category (category_id),
+    INDEX idx_device_nas_ip   (nas_ip),
+    INDEX idx_device_active   (is_active),
+    CONSTRAINT fk_device_category
+        FOREIGN KEY (category_id) REFERENCES nas_categories(id) ON DELETE SET NULL
+) ENGINE=InnoDB;
+
+COMMIT;

--- a/database/migrations/009_device_registry_name.sql
+++ b/database/migrations/009_device_registry_name.sql
@@ -1,0 +1,9 @@
+﻿-- Migration 009: Add nullable name to device_registry
+-- Keeps backward compatibility with existing historical rows.
+
+START TRANSACTION;
+
+ALTER TABLE device_registry
+    ADD COLUMN name VARCHAR(120) NULL DEFAULT NULL AFTER mac;
+
+COMMIT;

--- a/frontend/src/pages/DeviceRegistry.jsx
+++ b/frontend/src/pages/DeviceRegistry.jsx
@@ -1,0 +1,2 @@
+﻿// Re-export DeviceRegistryTab as DeviceRegistry for backward compatibility
+export { default } from './DeviceRegistryTab';

--- a/frontend/src/pages/DeviceRegistryTab.jsx
+++ b/frontend/src/pages/DeviceRegistryTab.jsx
@@ -1,0 +1,529 @@
+﻿import React, { useState, useRef } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { Cpu, Plus, Trash2, Edit2, X, Upload, CheckCircle, AlertTriangle, Search, Download } from 'lucide-react'
+import { useAuth } from '../context/AuthContext'
+import { useToast } from '../context/ToastContext'
+import DeviceRegistryService from '../services/deviceRegistry'
+import NasCategoriesService from '../services/nasCategoriesService'
+
+const EMPTY_FORM = { mac: '', name: '', category_id: '', nas_ip: '', description: '', is_active: 1 }
+
+export default function DeviceRegistryTab() {
+    const { hasRole } = useAuth()
+    const { showToast } = useToast()
+    const queryClient = useQueryClient()
+    const canWrite = hasRole(['superadmin', 'admin'])
+    const canDelete = hasRole(['superadmin'])
+
+    const [showModal, setShowModal] = useState(false)
+    const [editItem, setEditItem] = useState(null)
+    const [form, setForm] = useState(EMPTY_FORM)
+    const [deleteTarget, setDeleteTarget] = useState(null)
+    const [search, setSearch] = useState('')
+    const [filterCategory, setFilterCategory] = useState('')
+    const [showBulk, setShowBulk] = useState(false)
+    const [bulkText, setBulkText] = useState('')
+    const [bulkCategoryId, setBulkCategoryId] = useState('')
+    const [bulkResult, setBulkResult] = useState(null)
+    const fileInputRef = useRef(null)
+
+    const invalidate = () => queryClient.invalidateQueries({ queryKey: ['device-registry'] })
+
+    const { data: devices = [], isLoading } = useQuery({
+        queryKey: ['device-registry'],
+        queryFn: () => DeviceRegistryService.getAll(),
+    })
+
+    const { data: categories = [] } = useQuery({
+        queryKey: ['nas-categories'],
+        queryFn: NasCategoriesService.getAll,
+    })
+
+    const { data: stats } = useQuery({
+        queryKey: ['device-registry', 'stats'],
+        queryFn: DeviceRegistryService.getStats,
+    })
+
+    const createMutation = useMutation({
+        mutationFn: DeviceRegistryService.create,
+        onSuccess: () => { invalidate(); closeModal(); showToast('Device registered', 'success') },
+        onError: (e) => showToast(e.response?.data?.detail || 'Error creating device', 'error'),
+    })
+
+    const updateMutation = useMutation({
+        mutationFn: ({ id, data }) => DeviceRegistryService.update(id, data),
+        onSuccess: () => { invalidate(); closeModal(); showToast('Device updated', 'success') },
+        onError: (e) => showToast(e.response?.data?.detail || 'Error updating device', 'error'),
+    })
+
+    const deleteMutation = useMutation({
+        mutationFn: DeviceRegistryService.remove,
+        onSuccess: () => { invalidate(); setDeleteTarget(null); showToast('Device removed', 'success') },
+        onError: (e) => showToast(e.response?.data?.detail || 'Error deleting device', 'error'),
+    })
+
+    const bulkMutation = useMutation({
+        mutationFn: (payload) => DeviceRegistryService.bulkCreate(payload),
+        onSuccess: (result) => {
+            invalidate()
+            setBulkResult(result)
+            showToast(`Created: ${result.created}, Updated: ${result.updated}`, 'success')
+        },
+        onError: (e) => showToast(e.response?.data?.detail || 'Bulk import failed', 'error'),
+    })
+
+    const csvMutation = useMutation({
+        mutationFn: ({ file, categoryId }) => DeviceRegistryService.bulkCsv(file, categoryId || null),
+        onSuccess: (result) => {
+            invalidate()
+            setBulkResult(result)
+            showToast(`Created: ${result.created}, Updated: ${result.updated}`, 'success')
+        },
+        onError: (e) => showToast(e.response?.data?.detail || 'CSV import failed', 'error'),
+    })
+
+    const openCreate = () => { setEditItem(null); setForm(EMPTY_FORM); setShowModal(true) }
+    const openEdit = (item) => {
+        setEditItem(item)
+        setForm({
+            mac: item.mac,
+            name: item.name ?? '',
+            category_id: item.category_id ?? '',
+            nas_ip: item.nas_ip ?? '',
+            description: item.description ?? '',
+            is_active: item.is_active,
+        })
+        setShowModal(true)
+    }
+    const closeModal = () => { setShowModal(false); setEditItem(null); setForm(EMPTY_FORM) }
+
+    const handleSubmit = (e) => {
+        e.preventDefault()
+        const payload = {
+            mac: form.mac,
+            name: form.name || null,
+            category_id: form.category_id ? parseInt(form.category_id, 10) : null,
+            nas_ip: form.nas_ip || null,
+            description: form.description || null,
+            is_active: form.is_active,
+        }
+        if (editItem) {
+            updateMutation.mutate({ id: editItem.id, data: payload })
+        } else {
+            createMutation.mutate(payload)
+        }
+    }
+
+    const handleBulkText = () => {
+        const lines = bulkText.split('\n').map(l => l.trim()).filter(Boolean)
+        const rowErrors = []
+        const devices = lines.map(line => {
+            const parts = line.split(',')
+            const mac = parts[0]?.trim()
+            const nasIp = parts[1]?.trim() || null
+            const name = parts[2]?.trim() || null
+            const description = parts[3]?.trim() || null
+            const rowCategory = parts[4]?.trim()
+            const parsedRowCategory = rowCategory ? parseInt(rowCategory, 10) : null
+
+            if (!mac || !nasIp || !name || !description) {
+                rowErrors.push(`Row "${line}": required format is mac,nas_ip,name,description[,category_id]`)
+                return null
+            }
+
+            return {
+                mac,
+                nas_ip: nasIp,
+                name,
+                description,
+                category_id: Number.isInteger(parsedRowCategory) ? parsedRowCategory : (bulkCategoryId ? parseInt(bulkCategoryId, 10) : null),
+                is_active: 1,
+            }
+        }).filter(Boolean)
+
+        if (rowErrors.length > 0) {
+            showToast(rowErrors[0], 'error')
+            return
+        }
+
+        bulkMutation.mutate({
+            devices,
+            category_id: bulkCategoryId ? parseInt(bulkCategoryId, 10) : null,
+        })
+    }
+
+    const handleDownloadTemplate = async () => {
+        try {
+            const blob = await DeviceRegistryService.downloadBulkTemplate()
+            const url = window.URL.createObjectURL(new Blob([blob], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' }))
+            const link = document.createElement('a')
+            link.href = url
+            link.setAttribute('download', 'device_registry_bulk_template.xlsx')
+            document.body.appendChild(link)
+            link.click()
+            document.body.removeChild(link)
+            window.URL.revokeObjectURL(url)
+        } catch (e) {
+            showToast(e.response?.data?.detail || 'Template download failed', 'error')
+        }
+    }
+
+    const handleCsvUpload = (e) => {
+        const file = e.target.files?.[0]
+        if (!file) return
+        csvMutation.mutate({ file, categoryId: bulkCategoryId ? parseInt(bulkCategoryId, 10) : null })
+        e.target.value = ''
+    }
+
+    const filtered = devices.filter(d => {
+        const term = search.toLowerCase()
+        const matchSearch = !term || d.mac.includes(term) ||
+            (d.name || '').toLowerCase().includes(term) ||
+            (d.description || '').toLowerCase().includes(term) ||
+            (d.nas_ip || '').includes(term)
+        const matchCat = !filterCategory || String(d.category_id) === filterCategory
+        return matchSearch && matchCat
+    })
+
+    return (
+        <div className="space-y-6 pb-10 px-4">
+            <div className="py-4">
+                <h2 className="text-3xl font-extrabold text-slate-800 tracking-tight flex items-center gap-3">
+                    <Cpu className="text-indigo-600" size={32} />
+                    Device Registry
+                </h2>
+                <p className="text-slate-500 mt-1 text-xs font-black uppercase tracking-widest opacity-60">
+                    Register endpoint devices (SMs, CPEs) by MAC ÔÇö assign to category for policy resolution
+                </p>
+            </div>
+
+            {/* ÔöÇÔöÇ Info Box: What is the Device Registry? ÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇÔöÇ */}
+            <div className="bg-indigo-50 border border-indigo-200 rounded-2xl p-4 mb-2">
+                <div className="flex items-center gap-2 mb-2">
+                    <Cpu size={15} className="text-indigo-500" />
+                    <h3 className="text-xs font-black text-indigo-700 uppercase tracking-widest">What is the Device Registry?</h3>
+                </div>
+                <p className="text-sm text-slate-600 leading-relaxed">
+                    The Device Registry solves <strong>MACÔåÆcategory policy lookup</strong> in Step 1.5 of the RADIUS auth flow.
+                    In RADIUS-proxy scenarios, parent NAS devices share an IP but endpoint devices have different MACs ÔÇö
+                    the registry maps each MAC to its category for policy resolution. Use <strong>NAS Devices</strong> to manage
+                    RADIUS NAS/proxy configuration; use <strong>Device Registry</strong> to register endpoint devices (SMs, CPEs).
+                </p>
+            </div>
+
+            {/* Stats + Actions */}
+            <div className="flex flex-col lg:flex-row lg:items-center justify-between gap-4">
+                <div className="flex items-center gap-4 px-5 py-2.5 bg-white border border-slate-200 rounded-2xl shadow-sm text-xs font-black text-slate-500 uppercase tracking-widest">
+                    <span className="flex items-center gap-1.5">
+                        <Cpu size={13} className="text-indigo-400" />
+                        {stats?.total ?? 'ÔÇª'} Devices
+                    </span>
+                    <span className="w-px h-4 bg-slate-200" />
+                    <span className="flex items-center gap-1.5 text-emerald-600">
+                        <CheckCircle size={13} /> {stats?.active ?? 'ÔÇª'} Active
+                    </span>
+                </div>
+                {canWrite && (
+                    <div className="flex items-center gap-2">
+                        <button
+                            onClick={() => { setShowBulk(true); setBulkResult(null) }}
+                            className="flex items-center gap-2 px-4 py-2.5 bg-slate-100 text-slate-700 rounded-xl font-black text-xs hover:bg-slate-200 transition-colors"
+                        >
+                            <Upload size={15} /> Bulk Import
+                        </button>
+                        <button
+                            onClick={openCreate}
+                            className="flex items-center gap-2 px-5 py-2.5 bg-indigo-600 text-white rounded-xl font-black text-xs hover:bg-indigo-700 transition-colors shadow-sm"
+                        >
+                            <Plus size={16} /> Add Device
+                        </button>
+                    </div>
+                )}
+            </div>
+
+            {/* Filters */}
+            <div className="flex gap-3 items-center">
+                <div className="relative">
+                    <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400" size={14} />
+                    <input
+                        className="pl-8 pr-3 py-2 text-sm border border-slate-200 rounded-xl outline-none focus:ring-2 focus:ring-indigo-500 bg-white"
+                        placeholder="Search MAC, name, description, IPÔÇª"
+                        value={search}
+                        onChange={e => setSearch(e.target.value)}
+                    />
+                </div>
+                <select
+                    className="px-3 py-2 text-sm border border-slate-200 rounded-xl outline-none focus:ring-2 focus:ring-indigo-500 bg-white"
+                    value={filterCategory}
+                    onChange={e => setFilterCategory(e.target.value)}
+                >
+                    <option value="">All categories</option>
+                    {categories.map(c => <option key={c.id} value={String(c.id)}>{c.name}</option>)}
+                </select>
+            </div>
+
+            {/* Table */}
+            <div className="bg-white rounded-2xl shadow-lg border border-slate-200 overflow-hidden">
+                {isLoading ? (
+                    <div className="flex items-center justify-center py-16">
+                        <div className="w-8 h-8 border-4 border-indigo-600 border-t-transparent rounded-full animate-spin" />
+                    </div>
+                ) : filtered.length === 0 ? (
+                    <div className="text-center py-16 text-slate-400">
+                        <Cpu size={40} className="mx-auto mb-3 opacity-30" />
+                        <p className="font-bold text-sm">No devices registered</p>
+                        <p className="text-xs mt-1">Add devices manually or use Bulk Import</p>
+                    </div>
+                ) : (
+                    <table className="w-full text-sm">
+                        <thead>
+                            <tr className="border-b border-slate-100 bg-slate-50">
+                                <th className="text-left px-5 py-3 text-[10px] font-black text-slate-500 uppercase tracking-widest">MAC</th>
+                                <th className="text-left px-5 py-3 text-[10px] font-black text-slate-500 uppercase tracking-widest">Name</th>
+                                <th className="text-left px-5 py-3 text-[10px] font-black text-slate-500 uppercase tracking-widest">Category</th>
+                                <th className="text-left px-5 py-3 text-[10px] font-black text-slate-500 uppercase tracking-widest">AP IP</th>
+                                <th className="text-left px-5 py-3 text-[10px] font-black text-slate-500 uppercase tracking-widest">Description</th>
+                                <th className="text-left px-5 py-3 text-[10px] font-black text-slate-500 uppercase tracking-widest">Status</th>
+                                {canWrite && <th className="px-5 py-3" />}
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {filtered.map(d => (
+                                <tr key={d.id} className="border-b border-slate-50 hover:bg-slate-50 transition-colors">
+                                    <td className="px-5 py-3 font-mono text-xs font-bold text-slate-700">
+                                        {d.mac.match(/.{1,2}/g).join(':')}
+                                    </td>
+                                    <td className="px-5 py-3 text-xs font-semibold text-slate-700">{d.name || 'ÔÇö'}</td>
+                                    <td className="px-5 py-3">
+                                        {d.category_name
+                                            ? <span className="px-2 py-0.5 bg-indigo-100 text-indigo-700 rounded-full text-[10px] font-black uppercase">{d.category_name}</span>
+                                            : <span className="text-slate-400 text-xs">ÔÇö</span>}
+                                    </td>
+                                    <td className="px-5 py-3 font-mono text-xs text-slate-500">{d.nas_ip || 'ÔÇö'}</td>
+                                    <td className="px-5 py-3 text-xs text-slate-500">{d.description || 'ÔÇö'}</td>
+                                    <td className="px-5 py-3">
+                                        {d.is_active
+                                            ? <span className="px-2 py-0.5 bg-emerald-100 text-emerald-700 rounded-full text-[10px] font-black">Active</span>
+                                            : <span className="px-2 py-0.5 bg-slate-100 text-slate-500 rounded-full text-[10px] font-black">Inactive</span>}
+                                    </td>
+                                    {canWrite && (
+                                        <td className="px-5 py-3">
+                                            <div className="flex items-center gap-2 justify-end">
+                                                <button onClick={() => openEdit(d)} className="p-1.5 text-slate-400 hover:text-indigo-600 hover:bg-indigo-50 rounded-lg transition-colors">
+                                                    <Edit2 size={13} />
+                                                </button>
+                                                {canDelete && (
+                                                    <button onClick={() => setDeleteTarget(d)} className="p-1.5 text-slate-400 hover:text-rose-600 hover:bg-rose-50 rounded-lg transition-colors">
+                                                        <Trash2 size={13} />
+                                                    </button>
+                                                )}
+                                            </div>
+                                        </td>
+                                    )}
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                )}
+            </div>
+
+            {/* Create/Edit Modal */}
+            {showModal && (
+                <div className="fixed inset-0 bg-slate-900/80 backdrop-blur-sm z-[100] flex items-center justify-center p-4">
+                    <div className="bg-white rounded-3xl w-full max-w-md shadow-2xl overflow-hidden">
+                        <div className="p-6 bg-slate-50 border-b flex justify-between items-center">
+                            <h3 className="text-lg font-black text-slate-800">
+                                {editItem ? 'Edit Device' : 'Register Device'}
+                            </h3>
+                            <button onClick={closeModal} className="p-2 hover:bg-slate-200 rounded-full transition-colors text-slate-500">
+                                <X size={18} />
+                            </button>
+                        </div>
+                        <form onSubmit={handleSubmit} className="p-6 space-y-4">
+                            <div>
+                                <label className="block text-[10px] font-black text-slate-500 uppercase tracking-widest mb-1.5">MAC Address *</label>
+                                <input
+                                    required
+                                    placeholder="e.g. 0A:00:3E:45:76:4A"
+                                    className="w-full px-4 py-2.5 border border-slate-200 rounded-xl outline-none focus:ring-2 focus:ring-indigo-500 text-sm font-mono disabled:bg-slate-50 disabled:cursor-not-allowed"
+                                    value={form.mac}
+                                    onChange={e => setForm(f => ({ ...f, mac: e.target.value }))}
+                                    disabled={!!editItem}
+                                />
+                            </div>
+                            <div>
+                                <label className="block text-[10px] font-black text-slate-500 uppercase tracking-widest mb-1.5">Name</label>
+                                <input
+                                    placeholder="e.g. SM Torre Norte"
+                                    className="w-full px-4 py-2.5 border border-slate-200 rounded-xl outline-none focus:ring-2 focus:ring-indigo-500 text-sm"
+                                    value={form.name}
+                                    onChange={e => setForm(f => ({ ...f, name: e.target.value }))}
+                                />
+                            </div>
+                            <div>
+                                <label className="block text-[10px] font-black text-slate-500 uppercase tracking-widest mb-1.5">Category</label>
+                                <select
+                                    className="w-full px-4 py-2.5 border border-slate-200 rounded-xl outline-none focus:ring-2 focus:ring-indigo-500 text-sm bg-white"
+                                    value={form.category_id}
+                                    onChange={e => setForm(f => ({ ...f, category_id: e.target.value }))}
+                                >
+                                    <option value="">ÔÇö None ÔÇö</option>
+                                    {categories.map(c => <option key={c.id} value={c.id}>{c.name}</option>)}
+                                </select>
+                            </div>
+                            <div>
+                                <label className="block text-[10px] font-black text-slate-500 uppercase tracking-widest mb-1.5">AP IP (optional)</label>
+                                <input
+                                    placeholder="e.g. 192.168.1.11"
+                                    className="w-full px-4 py-2.5 border border-slate-200 rounded-xl outline-none focus:ring-2 focus:ring-indigo-500 text-sm font-mono"
+                                    value={form.nas_ip}
+                                    onChange={e => setForm(f => ({ ...f, nas_ip: e.target.value }))}
+                                />
+                            </div>
+                            <div>
+                                <label className="block text-[10px] font-black text-slate-500 uppercase tracking-widest mb-1.5">Description</label>
+                                <input
+                                    placeholder="e.g. SM Torre Norte"
+                                    className="w-full px-4 py-2.5 border border-slate-200 rounded-xl outline-none focus:ring-2 focus:ring-indigo-500 text-sm"
+                                    value={form.description}
+                                    onChange={e => setForm(f => ({ ...f, description: e.target.value }))}
+                                />
+                            </div>
+                            <div className="flex items-center gap-3">
+                                <input
+                                    type="checkbox"
+                                    id="dev-active"
+                                    checked={form.is_active === 1}
+                                    onChange={e => setForm(f => ({ ...f, is_active: e.target.checked ? 1 : 0 }))}
+                                    className="w-4 h-4 rounded"
+                                />
+                                <label htmlFor="dev-active" className="text-sm font-bold text-slate-700">Active</label>
+                            </div>
+                            <div className="flex gap-3 pt-2">
+                                <button type="button" onClick={closeModal} className="flex-1 px-4 py-2.5 border border-slate-200 rounded-xl text-sm font-bold text-slate-600 hover:bg-slate-50">Cancel</button>
+                                <button type="submit" className="flex-1 px-4 py-2.5 bg-indigo-600 text-white rounded-xl text-sm font-bold hover:bg-indigo-700 transition-colors">
+                                    {editItem ? 'Save' : 'Register'}
+                                </button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            )}
+
+            {/* Bulk Import Modal */}
+            {showBulk && (
+                <div className="fixed inset-0 bg-slate-900/80 backdrop-blur-sm z-[100] flex items-center justify-center p-4">
+                    <div className="bg-white rounded-3xl w-full max-w-lg shadow-2xl overflow-hidden">
+                        <div className="p-6 bg-slate-50 border-b flex justify-between items-center">
+                            <h3 className="text-lg font-black text-slate-800">Bulk Import Devices</h3>
+                            <button onClick={() => setShowBulk(false)} className="p-2 hover:bg-slate-200 rounded-full text-slate-500">
+                                <X size={18} />
+                            </button>
+                        </div>
+                        <div className="p-6 space-y-4">
+                            <div>
+                                <label className="block text-[10px] font-black text-slate-500 uppercase tracking-widest mb-1.5">Default Category</label>
+                                <select
+                                    className="w-full px-4 py-2.5 border border-slate-200 rounded-xl outline-none focus:ring-2 focus:ring-indigo-500 text-sm bg-white"
+                                    value={bulkCategoryId}
+                                    onChange={e => setBulkCategoryId(e.target.value)}
+                                >
+                                    <option value="">ÔÇö None ÔÇö</option>
+                                    {categories.map(c => <option key={c.id} value={c.id}>{c.name}</option>)}
+                                </select>
+                            </div>
+
+                            {/* CSV Upload */}
+                            <div className="border-2 border-dashed border-slate-200 rounded-xl p-4 text-center">
+                                <Upload size={24} className="mx-auto mb-2 text-slate-400" />
+                                <p className="text-xs font-bold text-slate-600 mb-1">Upload CSV file</p>
+                                <p className="text-[10px] text-slate-400 mb-3">Required columns: mac, nas_ip, name, description ┬À Optional: category_id</p>
+                                <div className="flex justify-center gap-2">
+                                    <button
+                                        type="button"
+                                        onClick={() => fileInputRef.current?.click()}
+                                        disabled={csvMutation.isPending}
+                                        className="px-4 py-2 bg-slate-100 text-slate-700 rounded-lg text-xs font-bold hover:bg-slate-200 transition-colors disabled:opacity-50"
+                                    >
+                                        {csvMutation.isPending ? 'ImportingÔÇª' : 'Choose CSV'}
+                                    </button>
+                                    <button
+                                        type="button"
+                                        onClick={handleDownloadTemplate}
+                                        className="px-4 py-2 bg-indigo-50 text-indigo-700 rounded-lg text-xs font-bold hover:bg-indigo-100 transition-colors"
+                                    >
+                                        <span className="inline-flex items-center gap-1.5"><Download size={12} /> Descargar template</span>
+                                    </button>
+                                </div>
+                                <input ref={fileInputRef} type="file" accept=".csv" className="hidden" onChange={handleCsvUpload} />
+                            </div>
+
+                            <div className="text-center text-xs text-slate-400 font-bold">ÔÇö or paste device list ÔÇö</div>
+
+                            {/* Text Paste */}
+                            <div>
+                                <p className="text-[10px] text-slate-400 mb-1.5">One per line: mac,nas_ip,name,description[,category_id]</p>
+                                <textarea
+                                    className="w-full px-3 py-2 border border-slate-200 rounded-xl outline-none focus:ring-2 focus:ring-indigo-500 text-xs font-mono h-32 resize-none"
+                                    placeholder={"0a003e45764a,192.168.1.10,SM Torre Norte,Cliente premium\n0a003e45764b,192.168.1.11,SM Torre Sur,Backhaul secundario,2"}
+                                    value={bulkText}
+                                    onChange={e => setBulkText(e.target.value)}
+                                />
+                            </div>
+
+                            {bulkResult && (
+                                <div className={`p-3 rounded-xl text-xs font-bold ${bulkResult.errors.length > 0 ? 'bg-amber-50 border border-amber-200 text-amber-800' : 'bg-emerald-50 border border-emerald-200 text-emerald-800'}`}>
+                                    <div className="flex items-center gap-2 mb-1">
+                                        {bulkResult.errors.length > 0 ? <AlertTriangle size={14} /> : <CheckCircle size={14} />}
+                                        Created: {bulkResult.created} ┬À Updated: {bulkResult.updated} ┬À Errors: {bulkResult.errors.length}
+                                    </div>
+                                    {bulkResult.errors.slice(0, 5).map((err, i) => (
+                                        <div key={i} className="font-mono text-[10px] mt-0.5">{err}</div>
+                                    ))}
+                                    {bulkResult.errors.length > 5 && (
+                                        <div className="text-[10px] mt-0.5">ÔÇªand {bulkResult.errors.length - 5} more</div>
+                                    )}
+                                </div>
+                            )}
+
+                            <div className="flex gap-3">
+                                <button onClick={() => setShowBulk(false)} className="flex-1 px-4 py-2.5 border border-slate-200 rounded-xl text-sm font-bold text-slate-600 hover:bg-slate-50">Close</button>
+                                <button
+                                    onClick={handleBulkText}
+                                    disabled={!bulkText.trim() || bulkMutation.isPending}
+                                    className="flex-1 px-4 py-2.5 bg-indigo-600 text-white rounded-xl text-sm font-bold hover:bg-indigo-700 disabled:opacity-50 transition-colors"
+                                >
+                                    {bulkMutation.isPending ? 'ImportingÔÇª' : 'Import List'}
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            {/* Delete Confirm */}
+            {deleteTarget && (
+                <div className="fixed inset-0 bg-slate-900/80 backdrop-blur-sm z-[100] flex items-center justify-center p-4">
+                    <div className="bg-white rounded-3xl w-full max-w-sm shadow-2xl p-8 space-y-4">
+                        <div className="w-14 h-14 rounded-full bg-rose-100 flex items-center justify-center mx-auto">
+                            <AlertTriangle size={24} className="text-rose-600" />
+                        </div>
+                        <div className="text-center">
+                            <h3 className="font-black text-slate-800 text-lg">Remove Device?</h3>
+                            <p className="text-slate-500 text-sm mt-1 font-mono">{deleteTarget.mac}</p>
+                        </div>
+                        <div className="flex gap-3">
+                            <button onClick={() => setDeleteTarget(null)} className="flex-1 px-4 py-2.5 border border-slate-200 rounded-xl text-sm font-bold text-slate-600 hover:bg-slate-50">Cancel</button>
+                            <button
+                                onClick={() => deleteMutation.mutate(deleteTarget.id)}
+                                className="flex-1 px-4 py-2.5 bg-rose-600 text-white rounded-xl text-sm font-bold hover:bg-rose-700 transition-colors"
+                            >
+                                Remove
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
+        </div>
+    )
+}

--- a/frontend/src/services/deviceRegistry.js
+++ b/frontend/src/services/deviceRegistry.js
@@ -1,0 +1,51 @@
+﻿import api from '../api';
+
+const DeviceRegistryService = {
+  getAll: async (params = {}) => {
+    const r = await api.get('/device-registry', { params });
+    return r.data;
+  },
+
+  getStats: async () => {
+    const r = await api.get('/device-registry/stats');
+    return r.data;
+  },
+
+  create: async (data) => {
+    const r = await api.post('/device-registry', data);
+    return r.data;
+  },
+
+  update: async (id, data) => {
+    const r = await api.put(`/device-registry/${id}`, data);
+    return r.data;
+  },
+
+  remove: async (id) => {
+    const r = await api.delete(`/device-registry/${id}`);
+    return r.data;
+  },
+
+  bulkCreate: async (payload) => {
+    const r = await api.post('/device-registry/bulk', payload);
+    return r.data;
+  },
+
+  bulkCsv: async (file, defaultCategoryId) => {
+    const form = new FormData();
+    form.append('file', file);
+    const params = defaultCategoryId ? { default_category_id: defaultCategoryId } : {};
+    const r = await api.post('/device-registry/bulk/csv', form, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+      params,
+    });
+    return r.data;
+  },
+
+  downloadBulkTemplate: async () => {
+    const r = await api.get('/device-registry/bulk/template', { responseType: 'blob' });
+    return r.data;
+  },
+};
+
+export default DeviceRegistryService;

--- a/frontend/src/test/DeviceRegistryPage.test.jsx
+++ b/frontend/src/test/DeviceRegistryPage.test.jsx
@@ -1,0 +1,98 @@
+﻿import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
+import DeviceRegistryPage from '../pages/DeviceRegistry'
+import { AuthProvider } from '../context/AuthContext'
+import { ToastProvider } from '../context/ToastContext'
+import DeviceRegistryService from '../services/deviceRegistry'
+import NasCategoriesService from '../services/nasCategoriesService'
+
+vi.mock('../services/deviceRegistry', () => ({
+  default: {
+    getAll: vi.fn(),
+    getStats: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    remove: vi.fn(),
+    bulkCreate: vi.fn(),
+    bulkCsv: vi.fn(),
+    downloadBulkTemplate: vi.fn(),
+  },
+}))
+
+vi.mock('../services/nasCategoriesService', () => ({
+  default: {
+    getAll: vi.fn(),
+  },
+}))
+
+function makeJwt(role) {
+  const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_')
+  const body = btoa(JSON.stringify({ sub: 'test_admin', role, exp: 9999999999 })).replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_')
+  return `${header}.${body}.fakesig`
+}
+
+function renderDeviceRegistry(role = 'admin') {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider initialToken={makeJwt(role)}>
+          <ToastProvider>
+            <DeviceRegistryPage />
+          </ToastProvider>
+        </AuthProvider>
+      </QueryClientProvider>
+    </MemoryRouter>
+  )
+}
+
+describe('DeviceRegistry page bulk import helpers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    DeviceRegistryService.getAll.mockResolvedValue([])
+    DeviceRegistryService.getStats.mockResolvedValue({ total: 0, active: 0 })
+    DeviceRegistryService.create.mockResolvedValue({})
+    DeviceRegistryService.update.mockResolvedValue({})
+    DeviceRegistryService.remove.mockResolvedValue({ ok: true })
+    DeviceRegistryService.bulkCreate.mockResolvedValue({ created: 0, updated: 0, errors: [] })
+    DeviceRegistryService.bulkCsv.mockResolvedValue({ created: 0, updated: 0, errors: [] })
+    DeviceRegistryService.downloadBulkTemplate.mockResolvedValue(new Blob(['header'], { type: 'text/csv' }))
+
+    NasCategoriesService.getAll.mockResolvedValue([{ id: 2, name: 'SM_CAMBIUM' }])
+
+    globalThis.URL.createObjectURL = vi.fn(() => 'blob:mock-template')
+    globalThis.URL.revokeObjectURL = vi.fn()
+    HTMLAnchorElement.prototype.click = vi.fn()
+  })
+
+  it('shows template download action and required columns including name', async () => {
+    const user = userEvent.setup()
+    renderDeviceRegistry('admin')
+
+    await user.click(await screen.findByRole('button', { name: /bulk import/i }))
+
+    expect(screen.getByText(/required columns: mac, nas_ip, name, description/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /descargar template/i })).toBeInTheDocument()
+    expect(screen.getByText(/one per line: mac,nas_ip,name,description/i)).toBeInTheDocument()
+  })
+
+  it('calls downloadBulkTemplate when user clicks Descargar template', async () => {
+    const user = userEvent.setup()
+    renderDeviceRegistry('admin')
+
+    await user.click(await screen.findByRole('button', { name: /bulk import/i }))
+    await user.click(screen.getByRole('button', { name: /descargar template/i }))
+
+    await waitFor(() => {
+      expect(DeviceRegistryService.downloadBulkTemplate).toHaveBeenCalledTimes(1)
+    })
+  })
+})


### PR DESCRIPTION
- New router: device_registry.py with CRUD + bulk operations
- New schemas: device_registry.py Pydantic models with validators
- Frontend: DeviceRegistryTab page with bulk template download
- Frontend: deviceRegistry.js API service
- Database: device_registry table with name column
- Template download returns CSV with UTF-8 BOM (not XLSX)
- models.py: DeviceRegistry model + MAC normalization helpers
- models.py: RadAcct MAC validation (callingstationid)
- models.py: NasCategory.devices relationship to DeviceRegistry
